### PR TITLE
Implement the `VMThread` Container

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@
 
 #![warn(clippy::all, clippy::cargo)]
 
+extern crate core;
+
 pub mod constant;
 pub mod error;
 pub mod executor;

--- a/src/vm/instruction_stream/mod.rs
+++ b/src/vm/instruction_stream/mod.rs
@@ -37,7 +37,7 @@ pub const INSTRUCTION_STREAM_MAX_SIZE: u32 = u32::MAX;
 ///
 /// # Byte-Instruction Correspondence
 ///
-/// Where most [`crate::opcode::Opcode`]s occupy a single byte, the
+/// Where most [`Opcode`]s occupy a single byte, the
 /// [`crate::opcode::memory::PushN`] opcode is followed in the instruction
 /// stream by the data (of size `N` bytes) that needs to be pushed onto the
 /// stack.
@@ -60,7 +60,7 @@ pub const INSTRUCTION_STREAM_MAX_SIZE: u32 = u32::MAX;
 /// contain that many opcodes.
 #[derive(Debug)]
 pub struct InstructionStream {
-    /// The sequence of [`crate::opcode::Opcode`]s.
+    /// The sequence of [`Opcode`]s.
     instructions: Vec<DynOpcode>,
 }
 
@@ -155,7 +155,7 @@ pub struct ExecutionThread<'opcode> {
     /// in the sequence of instructions.
     instruction_pointer: u32,
 
-    /// The sequence of [`crate::opcode::Opcode`]s.
+    /// The sequence of [`Opcode`]s.
     instructions: &'opcode Vec<DynOpcode>,
 }
 
@@ -220,7 +220,7 @@ impl<'opcode> ExecutionThread<'opcode> {
         let new_pointer: u32 = if self.instruction_pointer as i64 + jump < 0 {
             return None;
         } else {
-            self.instruction_pointer - jump as u32
+            self.instruction_pointer + jump as u32
         };
         if let Some(opcode) = self.instructions.get(new_pointer as usize) {
             self.instruction_pointer = new_pointer;
@@ -228,6 +228,20 @@ impl<'opcode> ExecutionThread<'opcode> {
         } else {
             None
         }
+    }
+
+    /// Sets the execution position to the opcode at `offset` in the instruction
+    /// stream if possible, returning that opcode if so.
+    ///
+    /// Returns [`None`] if there is no opcode at `offset.
+    pub fn at(&mut self, offset: u32) -> Option<&DynOpcode> {
+        if offset as usize >= self.instructions.len() {
+            return None;
+        }
+
+        self.instruction_pointer = offset;
+
+        Some(self.current())
     }
 
     /// Gets the slice of opcodes in the requested range.

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -3,6 +3,7 @@
 pub mod instruction_stream;
 pub mod state;
 pub mod symbolic_value;
+pub mod vm_thread;
 
 /// The virtual machine used to perform symbolic execution of the contract
 /// bytecode.
@@ -10,6 +11,9 @@ pub mod symbolic_value;
 pub struct VM {}
 
 // TODO [Ara] Tracking for visited opcodes.
+
+// TODO [Ara] Some way of getting the "next opcode" in a way that is agnostic to
+//   which ET is running.
 
 // TODO [Ara] FIFO queue of branches, registered by their JUMPS. We only spawn
 //   new branches if the source jump hasn't been bifurcated and enqueued before.

--- a/src/vm/vm_thread.rs
+++ b/src/vm/vm_thread.rs
@@ -1,0 +1,86 @@
+//! This module contains the definition of the [`VMThread`] type, representing
+//! the divergent execution paths that can be taken during symbolic execution.
+
+use crate::vm::{instruction_stream::ExecutionThread, state::VMState};
+
+/// A `VMThread` is a representation of a given execution path during the course
+/// of symbolic execution.
+///
+/// The construct can be forked at will to represent the branches in execution,
+/// but contains no logic for performing that execution itself.
+pub struct VMThread<'et> {
+    /// The virtual machine's state for this thread of execution.
+    state: VMState,
+
+    /// The instruction stream and instruction pointer.
+    thread: ExecutionThread<'et>,
+}
+
+impl<'et> VMThread<'et> {
+    /// Constructs a new virtual machine thread with `state` as the initial
+    /// state at `thread.instruction_pointer()`.
+    pub fn new(state: VMState, thread: ExecutionThread<'et>) -> Self {
+        Self { state, thread }
+    }
+
+    /// Gets the current virtual machine state for this virtual machine thread.
+    pub fn state(&mut self) -> &mut VMState {
+        &mut self.state
+    }
+
+    /// Gets the instruction stream and current execution position associated
+    /// with this virtual machine thread.
+    pub fn instructions(&mut self) -> &mut ExecutionThread<'et> {
+        &mut self.thread
+    }
+
+    /// Forks the virtual machine thread at the current point of execution,
+    /// jumping the new thread to `target`.
+    ///
+    /// This method performs no validation as to whether the fork point is a
+    /// valid fork point. This is up to the VM itself.
+    pub fn fork(&self, target: u32) -> Self {
+        let instruction_pointer = self.thread.instruction_pointer();
+        let state = self.state.fork(instruction_pointer);
+        let mut thread = self.thread;
+        thread.at(target);
+
+        Self { state, thread }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::vm::{instruction_stream::InstructionStream, state::VMState, vm_thread::VMThread};
+
+    #[test]
+    fn can_fork_vm_thread() -> anyhow::Result<()> {
+        let instruction_stream = InstructionStream::try_from(
+            vec![0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06].as_slice(),
+        )?;
+        let state = VMState::default();
+        let execution_thread = instruction_stream.new_thread(0)?;
+        let mut vm_thread = VMThread::new(state, execution_thread);
+
+        // Step the execution to a different point.
+        vm_thread.thread.step().expect("Execution was not able to step");
+
+        // Now we can fork with a different jump target.
+        let mut forked_thread = vm_thread.fork(4);
+
+        // These move independently.
+        let forked_position_start = forked_thread.thread.instruction_pointer();
+        assert_ne!(
+            forked_position_start,
+            vm_thread.thread.instruction_pointer()
+        );
+        forked_thread.thread.step().expect("Execution was not able to step");
+        assert_ne!(
+            forked_position_start,
+            forked_thread.thread.instruction_pointer()
+        );
+        assert_eq!(forked_thread.thread.current().as_byte(), 0x05);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Summary

The virtual machine thread is a representation of a particular path of symbolic execution taken by the VM. It is used to manage the state splits that happen every time the symbolic executor is required to take a jump.

# Details

Nothing in particular.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
