### PR TITLE
Implement the memory-related opcodes

### DIFF
--- a/src/opcode/memory.rs
+++ b/src/opcode/memory.rs
@@ -11,7 +11,10 @@ use crate::{
     },
     error::OpcodeError,
     opcode::Opcode,
-    vm::VM,
+    vm::{
+        value::{known_data::KnownData, Provenance, SymbolicValue, SymbolicValueData},
+        VM,
+    },
 };
 
 /// The `CALLDATALOAD` opcode gets the input data for the current environment.
@@ -37,7 +40,33 @@ pub struct CallDataLoad;
 
 impl Opcode for CallDataLoad {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the current thread's stack from the VM
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // The offset defines where in the call data is read from
+        let offset = stack.pop()?;
+
+        // Construct a constant representing the word read
+        let size = SymbolicValue::new_known_value(
+            instruction_pointer,
+            KnownData::UInt {
+                value: 32u8.to_le_bytes().to_vec(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Then we construct the returned value
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::CallData { offset, size },
+        );
+
+        // And push it onto the stack
+        stack.push(value)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -75,7 +104,16 @@ pub struct CallDataSize;
 
 impl Opcode for CallDataSize {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack so a value can be pushed onto it
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Construct the value and push it onto the stack.
+        let length = SymbolicValue::new_value(instruction_pointer, Provenance::CallDataSize);
+        stack.push(length)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -123,7 +161,25 @@ pub struct CallDataCopy;
 
 impl Opcode for CallDataCopy {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the current stack to pull the inputs from
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the inputs
+        let dest_offset = stack.pop()?;
+        let offset = stack.pop()?;
+        let size = stack.pop()?;
+
+        // Modify the memory
+        let memory = vm.state()?.memory();
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::CallData { offset, size },
+        );
+        memory.store(dest_offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -160,7 +216,24 @@ pub struct CodeSize;
 
 impl Opcode for CodeSize {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the state
+        let instruction_pointer = vm.instruction_pointer()?;
+        let true_code_size = vm.instructions().len();
+        let stack = vm.stack()?;
+
+        // Construct the value
+        let code_size_constant = SymbolicValue::new_known_value(
+            instruction_pointer,
+            KnownData::UInt {
+                value: true_code_size.to_le_bytes().to_vec(),
+            },
+            Provenance::Execution,
+        );
+
+        // Push it onto the stack
+        stack.push(code_size_constant)?;
+
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -207,7 +280,25 @@ pub struct CodeCopy;
 
 impl Opcode for CodeCopy {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the current stack to pull the inputs from
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the inputs
+        let dest_offset = stack.pop()?;
+        let offset = stack.pop()?;
+        let size = stack.pop()?;
+
+        // Modify the memory
+        let memory = vm.state()?.memory();
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::CodeCopy { offset, size },
+        );
+        memory.store(dest_offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -249,7 +340,22 @@ pub struct ExtCodeSize;
 
 impl Opcode for ExtCodeSize {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and other necessities
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the target value from the stack
+        let address = stack.pop()?;
+
+        // Construct the value and push it onto the stack
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::ExtCodeSize { address },
+        );
+        stack.push(value)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -269,7 +375,7 @@ impl Opcode for ExtCodeSize {
     }
 }
 
-/// The `CODECOPY` opcode copies the current contract's code into memory.
+/// The `EXTCODECOPY` opcode copies the target contract's code into memory.
 ///
 /// # Semantics
 ///
@@ -298,7 +404,30 @@ pub struct ExtCodeCopy;
 
 impl Opcode for ExtCodeCopy {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and environment prerequisites
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Pull the inputs off the stack
+        let address = stack.pop()?;
+        let dest_offset = stack.pop()?;
+        let offset = stack.pop()?;
+        let size = stack.pop()?;
+
+        // Modify the memory
+        let memory = vm.state()?.memory();
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::ExtCodeCopy {
+                address,
+                offset,
+                size,
+            },
+        );
+        memory.store(dest_offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -340,7 +469,16 @@ pub struct ReturnDataSize;
 
 impl Opcode for ReturnDataSize {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and environment
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Construct the value and shove it onto the stack.
+        let size = SymbolicValue::new_value(instruction_pointer, Provenance::ReturnDataSize);
+        stack.push(size)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -388,7 +526,25 @@ pub struct ReturnDataCopy;
 
 impl Opcode for ReturnDataCopy {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the current stack to pull the inputs from
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the inputs
+        let dest_offset = stack.pop()?;
+        let offset = stack.pop()?;
+        let size = stack.pop()?;
+
+        // Modify the memory
+        let memory = vm.state()?.memory();
+        let value = SymbolicValue::new_from_program(
+            instruction_pointer,
+            SymbolicValueData::ReturnDataCopy { offset, size },
+        );
+        memory.store(dest_offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -429,7 +585,15 @@ pub struct Pop;
 
 impl Opcode for Pop {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and context data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Pop the value from the stack.
+        stack.pop()?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -472,7 +636,20 @@ pub struct MLoad;
 
 impl Opcode for MLoad {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the prerequisite data
+        let instruction_pointer = vm.instruction_pointer()?;
+
+        // Load the input from the stack
+        let offset = vm.stack()?.pop()?;
+
+        // Load the word at that offset from memory
+        let result = vm.state()?.memory().load(&offset).clone();
+
+        // Push it onto the stack
+        vm.stack()?.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -516,7 +693,19 @@ pub struct MStore;
 
 impl Opcode for MStore {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack
+        let stack = vm.stack()?;
+
+        // Get the inputs off the stack
+        let offset = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Write these to memory
+        let memory = vm.state()?.memory();
+        memory.store(offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -560,7 +749,19 @@ pub struct MStore8;
 
 impl Opcode for MStore8 {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack
+        let stack = vm.stack()?;
+
+        // Get the inputs off the stack
+        let offset = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Write these to memory
+        let memory = vm.state()?.memory();
+        memory.store_8(offset, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -603,7 +804,18 @@ pub struct SLoad;
 
 impl Opcode for SLoad {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the key from the stack
+        let key = vm.stack()?.pop()?;
+
+        // Read from storage using that key
+        let storage = vm.state()?.storage();
+        let result = storage.load(&key).clone();
+
+        // Write it into the stack
+        vm.stack()?.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -648,7 +860,18 @@ pub struct SStore;
 
 impl Opcode for SStore {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack
+        let stack = vm.stack()?;
+
+        // Load the inputs from the stack
+        let key = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Store the value into storage
+        vm.state()?.storage().store(key, value);
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -687,7 +910,18 @@ pub struct MSize;
 
 impl Opcode for MSize {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Prepare the value
+        let size = SymbolicValue::new_value(instruction_pointer, Provenance::MSize);
+
+        // Push it onto the stack
+        stack.push(size)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -724,7 +958,22 @@ pub struct Push0;
 
 impl Opcode for Push0 {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Construct the value of zero
+        let zero = SymbolicValue::new(
+            instruction_pointer,
+            SymbolicValueData::new_known(KnownData::zero()),
+            Provenance::Bytecode,
+        );
+
+        // Push it onto the stack
+        stack.push(zero)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -801,7 +1050,26 @@ impl PushN {
 
 impl Opcode for PushN {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Pull the data out of the opcode; validation is done in parsing
+        let item_data = self.bytes.clone();
+        let size = self.byte_count;
+
+        // Construct the value to push
+        let item = SymbolicValue::new(
+            instruction_pointer,
+            SymbolicValueData::new_known(KnownData::Bytes { value: item_data }),
+            Provenance::Bytecode,
+        );
+
+        // Push it onto the stack
+        stack.push(item)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -844,11 +1112,11 @@ impl Opcode for PushN {
 /// Execution is reverted if there is not enough gas or if there are not enough
 /// operands on the stack.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct Dup {
+pub struct DupN {
     item: u8,
 }
 
-impl Dup {
+impl DupN {
     /// Constructs a new instance of the `DUPN` opcode.
     ///
     /// # Errors
@@ -872,9 +1140,19 @@ impl Dup {
     }
 }
 
-impl Opcode for Dup {
+impl Opcode for DupN {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack
+        let stack = vm.stack()?;
+
+        // Get the dup frame, converting from EVM to internal semantics
+        let frame = self.item as u32 - 1;
+
+        // Duplicate the specified item; verification is done in parsing
+        stack.dup(frame)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -940,7 +1218,17 @@ impl SwapN {
 
 impl Opcode for SwapN {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack
+        let stack = vm.stack()?;
+
+        // Compute the internal item to swap with
+        let frame = self.n() as u32;
+
+        // Swap the items
+        stack.swap(frame)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -957,5 +1245,595 @@ impl Opcode for SwapN {
 
     fn as_byte(&self) -> u8 {
         SWAP_OPCODE_BASE_VALUE + self.item
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::random;
+
+    use crate::{
+        opcode::{memory, Opcode},
+        vm::{
+            state::memory::MemStoreSize,
+            value::{
+                known_data::KnownData,
+                BoxedVal,
+                Provenance,
+                SymbolicValue,
+                SymbolicValueData,
+            },
+        },
+    };
+
+    #[test]
+    fn call_data_load_inserts_value_with_correct_provenance() -> anyhow::Result<()> {
+        // First we have to prepare the virtual machine and the instruction
+        let input_offset = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let mut vm = util::new_vm_with_values_on_stack(vec![input_offset])?;
+
+        // Run the opcode
+        let opcode = memory::CallDataLoad;
+        opcode.execute(&mut vm)?;
+
+        // And then inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+
+        let item = stack.read(0)?;
+        assert_eq!(item.instruction_pointer, 0);
+        match &item.data {
+            SymbolicValueData::CallData { offset, .. } => {}
+            _ => panic!("Invalid data"),
+        };
+        assert_eq!(item.provenance, Provenance::Execution);
+
+        Ok(())
+    }
+
+    #[test]
+    fn call_data_size_pushes_sentinel_onto_stack() -> anyhow::Result<()> {
+        // Prepare the virtual-machine
+        let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+
+        // Run the opcode
+        let opcode = memory::CallDataSize;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        let value = stack.read(0)?;
+        assert_eq!(value.provenance, Provenance::CallDataSize);
+
+        Ok(())
+    }
+
+    #[test]
+    fn call_data_copy_copies_into_memory() -> anyhow::Result<()> {
+        // Prepare the values on stack and VM
+        let dest_offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_offset = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_size = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_size.clone(),
+            input_offset.clone(),
+            dest_offset.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::CallDataCopy;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert!(stack.is_empty());
+
+        // Inspect the memory
+        let memory = vm.state()?.memory();
+        let loaded = memory.load(&dest_offset);
+        match &loaded.data {
+            SymbolicValueData::CallData { offset, size } => {
+                assert_eq!(offset, &input_offset);
+                assert_eq!(size, &input_size);
+            }
+            _ => panic!("Incorrect payload"),
+        };
+        assert_eq!(loaded.provenance, Provenance::Execution);
+
+        Ok(())
+    }
+
+    #[test]
+    fn code_size_pushes_value_onto_stack() -> anyhow::Result<()> {
+        // First we have to prepare the virtual machine
+        let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+        let code_size_actual = vm.instructions().len();
+
+        // Run the opcode
+        let opcode = memory::CodeSize;
+        let result = opcode.execute(&mut vm);
+
+        // Check that the correct value is on the stack.
+        let value = vm.stack()?.read(0)?;
+        assert_eq!(value.provenance, Provenance::Execution);
+        match &value.data {
+            SymbolicValueData::KnownData { value, .. } => {
+                assert_eq!(
+                    value,
+                    &KnownData::UInt {
+                        value: code_size_actual.to_le_bytes().to_vec(),
+                    }
+                )
+            }
+            _ => panic!("Incorrect data payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn code_copy_copies_into_memory() -> anyhow::Result<()> {
+        // Prepare the values on stack and VM
+        let dest_offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_offset = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_size = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_size.clone(),
+            input_offset.clone(),
+            dest_offset.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::CodeCopy;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert!(stack.is_empty());
+
+        // Inspect the memory
+        let memory = vm.state()?.memory();
+        let loaded = memory.load(&dest_offset);
+        match &loaded.data {
+            SymbolicValueData::CodeCopy { offset, size } => {
+                assert_eq!(offset, &input_offset);
+                assert_eq!(size, &input_size);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+        assert_eq!(loaded.provenance, Provenance::Execution);
+
+        Ok(())
+    }
+
+    #[test]
+    fn ext_code_size_puts_value_on_stack() -> anyhow::Result<()> {
+        // Prepare the virtual machine
+        let address = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![address.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::ExtCodeSize;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        let value = stack.read(0)?;
+        assert_eq!(value.provenance, Provenance::Execution);
+        assert_eq!(value.data, SymbolicValueData::ExtCodeSize { address });
+
+        Ok(())
+    }
+
+    #[test]
+    fn ext_code_copy_copies_into_memory() -> anyhow::Result<()> {
+        // Prepare the values on stack and VM
+        let input_address = SymbolicValue::new_synthetic(7, SymbolicValueData::new_value());
+        let dest_offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_offset = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_size = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_size.clone(),
+            input_offset.clone(),
+            dest_offset.clone(),
+            input_address.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::ExtCodeCopy;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert!(stack.is_empty());
+
+        // Inspect the memory
+        let memory = vm.state()?.memory();
+        let loaded = memory.load(&dest_offset);
+        match &loaded.data {
+            SymbolicValueData::ExtCodeCopy {
+                address,
+                offset,
+                size,
+            } => {
+                assert_eq!(address, &input_address);
+                assert_eq!(offset, &input_offset);
+                assert_eq!(size, &input_size);
+            }
+            _ => panic!("Incorrect payload"),
+        };
+        assert_eq!(loaded.provenance, Provenance::Execution);
+
+        Ok(())
+    }
+
+    #[test]
+    fn return_data_size_pushes_value_onto_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::ReturnDataSize;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::ReturnDataSize);
+
+        Ok(())
+    }
+
+    #[test]
+    fn return_data_copy_copies_into_memory() -> anyhow::Result<()> {
+        // Prepare the values on stack and VM
+        let dest_offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_offset = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_size = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_size.clone(),
+            input_offset.clone(),
+            dest_offset.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::ReturnDataCopy;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert!(stack.is_empty());
+
+        // Inspect the memory
+        let memory = vm.state()?.memory();
+        let loaded = memory.load(&dest_offset);
+        match &loaded.data {
+            SymbolicValueData::ReturnDataCopy { offset, size } => {
+                assert_eq!(offset, &input_offset);
+                assert_eq!(size, &input_size);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+        assert_eq!(loaded.provenance, Provenance::Execution);
+
+        Ok(())
+    }
+
+    #[test]
+    fn pop_pops_value_from_stack() -> anyhow::Result<()> {
+        // Prepare the value on stack and the VM
+        let mut vm = util::new_vm_with_values_on_stack(vec![SymbolicValue::new_synthetic(
+            0,
+            SymbolicValueData::new_value(),
+        )])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::Pop;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        let stack = vm.stack()?;
+        assert!(stack.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn m_load_loads_word_from_memory() -> anyhow::Result<()> {
+        // Prepare the values and the vm
+        let offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let data = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![offset.clone()])?;
+        vm.state()?.memory().store(offset.clone(), data.clone());
+
+        // Prepare and run the opcode
+        let opcode = memory::MLoad;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        assert_eq!(stack.read(0)?, &data);
+
+        // Inspect the memory state
+        let memory = vm.state()?.memory();
+        assert_eq!(memory.load(&offset), &data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn m_store_stores_word_to_memory() -> anyhow::Result<()> {
+        // Prepare the values and the vm
+        let offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let data = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![data.clone(), offset.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::MStore;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        assert!(vm.stack()?.is_empty());
+
+        // Inspect the memory state
+        let memory = vm.state()?.memory();
+        assert_eq!(memory.load(&offset), &data);
+        assert_eq!(memory.query_store_size(&offset), Some(MemStoreSize::Word));
+
+        Ok(())
+    }
+
+    #[test]
+    fn m_store_8_stores_word_to_memory() -> anyhow::Result<()> {
+        // Prepare the values and the vm
+        let offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let data = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![data.clone(), offset.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::MStore8;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        assert!(vm.stack()?.is_empty());
+
+        // Inspect the memory state
+        let memory = vm.state()?.memory();
+        assert_eq!(memory.load(&offset), &data);
+        assert_eq!(memory.query_store_size(&offset), Some(MemStoreSize::Byte));
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_load_loads_word_from_storage() -> anyhow::Result<()> {
+        // Prepare the values and the vm
+        let key = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let value = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![key.clone()])?;
+        vm.state()?.storage().store(key.clone(), value.clone());
+
+        // Prepare and run the opcode
+        let opcode = memory::SLoad;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        assert_eq!(stack.read(0)?, &value);
+
+        // Inspect the storage state
+        let storage = vm.state()?.storage();
+        assert_eq!(storage.entry_count(), 1);
+        assert_eq!(storage.load(&key), &value);
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_store_writes_word_to_storage() -> anyhow::Result<()> {
+        // Prepare the values and the vm
+        let key = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let value = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![value.clone(), key.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::SStore;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack state
+        assert!(vm.stack()?.is_empty());
+
+        // Inspect the storage state
+        let storage = vm.state()?.storage();
+        assert_eq!(storage.entry_count(), 1);
+        assert_eq!(storage.load(&key), &value);
+
+        Ok(())
+    }
+
+    #[test]
+    fn m_size_writes_variable_to_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::MSize;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        let value = stack.read(0)?;
+        assert_eq!(value.provenance, Provenance::MSize);
+
+        Ok(())
+    }
+
+    #[test]
+    fn push_0_pushes_zero_onto_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+
+        // Prepare and run the opcode
+        let opcode = memory::Push0;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.size(), 1);
+        let value = stack.read(0)?;
+        assert_eq!(value.provenance, Provenance::Bytecode);
+        match &value.data {
+            SymbolicValueData::KnownData { value, .. } => assert_eq!(value, &KnownData::zero()),
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn push_n_pushes_encoded_value_onto_stack() -> anyhow::Result<()> {
+        // We want to test for all valid push sizes
+        for byte_count in 1..=32 {
+            // Generate some random data to push onto the stack
+            let mut bytes: Vec<u8> = Vec::new();
+            for _ in 0..byte_count {
+                bytes.push(random());
+            }
+
+            // Prepare the vm
+            let mut vm = util::new_vm_with_values_on_stack(vec![])?;
+
+            // Prepare and run the opcode
+            let opcode = memory::PushN {
+                byte_count,
+                bytes: bytes.clone(),
+            };
+            opcode.execute(&mut vm)?;
+
+            // Inspect the stack to check on things
+            let stack = vm.stack()?;
+            assert_eq!(stack.size(), 1);
+            let value = stack.read(0)?;
+            assert_eq!(value.provenance, Provenance::Bytecode);
+            match &value.data {
+                SymbolicValueData::KnownData { value, .. } => {
+                    assert_eq!(value, &KnownData::Bytes { value: bytes })
+                }
+                _ => panic!("Incorrect payload"),
+            };
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn dup_n_duplicates_specified_value_on_stack() -> anyhow::Result<()> {
+        // We want to test for all valid dup sizes
+        for item in 1..=16 {
+            // Prepare the items
+            let item_to_dup =
+                SymbolicValue::new_synthetic(0, SymbolicValueData::new_known(KnownData::zero()));
+            let other_item = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+
+            // Prepare the vm's stack
+            let mut stack: Vec<BoxedVal> = Vec::new();
+            stack.push(item_to_dup.clone());
+            for _ in 1..item {
+                stack.push(other_item.clone());
+            }
+
+            // Prepare the vm
+            let mut vm = util::new_vm_with_values_on_stack(stack)?;
+
+            // Prepare and run the opcode
+            let opcode = memory::DupN { item };
+            opcode.execute(&mut vm)?;
+
+            // Inspect the stack
+            let stack = vm.stack()?;
+            assert_eq!(stack.size(), item as usize + 1);
+            assert_eq!(stack.read(0)?, &item_to_dup);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn swap_swaps_values_on_stack() -> anyhow::Result<()> {
+        // We want to test for all the valid swap depths
+        for item in 1..=16 {
+            // Prepare the items
+            let stack_top =
+                SymbolicValue::new_synthetic(0, SymbolicValueData::new_known(KnownData::zero()));
+            let item_to_swap = SymbolicValue::new_synthetic(
+                1,
+                SymbolicValueData::new_known(KnownData::UInt {
+                    value: 1u32.to_le_bytes().to_vec(),
+                }),
+            );
+            let other_item = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+
+            // Prepare the VM's stack
+            let mut stack: Vec<BoxedVal> = Vec::new();
+            stack.push(item_to_swap.clone());
+            for _ in 0..item - 1 {
+                stack.push(other_item.clone());
+            }
+            stack.push(stack_top.clone());
+            let input_stack_size = stack.len();
+            assert_eq!(input_stack_size, item as usize + 1);
+
+            // Prepare the vm
+            let mut vm = util::new_vm_with_values_on_stack(stack)?;
+
+            // Prepare and run the opcode
+            let opcode = memory::SwapN { item };
+            opcode.execute(&mut vm)?;
+
+            // Inspect the stack
+            let stack = vm.stack()?;
+            assert_eq!(stack.size(), input_stack_size);
+            let item_at_depth = stack.read(item as u32)?;
+            let item_at_top = stack.read(0)?;
+            assert_eq!(item_at_depth, &stack_top);
+            assert_eq!(item_at_top, &item_to_swap);
+        }
+
+        Ok(())
+    }
+
+    mod util {
+        use crate::vm::{instructions::InstructionStream, value::BoxedVal, Config, VM};
+
+        /// Constructs a new virtual machine with the provided `values` pushed
+        /// onto its stack in order.
+        ///
+        /// This means that the last item in `values` will be put on the top of
+        /// the stack.
+        pub fn new_vm_with_values_on_stack(values: Vec<BoxedVal>) -> anyhow::Result<VM> {
+            // We don't actually care what these are for this test, so we just have
+            // _something_ long enough to account for what is going on.
+            let bytes: Vec<u8> = vec![
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x10, 0x11,
+            ];
+
+            let instructions = InstructionStream::try_from(bytes.as_slice())?;
+            let config = Config::default();
+
+            let mut vm = VM::new(instructions, config)?;
+            let stack = vm.stack()?;
+
+            values.into_iter().for_each(|val| {
+                stack.push(val).expect("Failed to insert value into stack");
+            });
+
+            Ok(vm)
+        }
     }
 }

--- a/src/vm/instructions/parser.rs
+++ b/src/vm/instructions/parser.rs
@@ -147,7 +147,7 @@ pub fn parse(bytes: &[u8]) -> anyhow::Result<Vec<DynOpcode>> {
                 }
                 0x80..=0x8f => {
                     let item_to_duplicate = byte - DUP_OPCODE_BASE_VALUE;
-                    let opcode = mem::Dup::new(item_to_duplicate)?;
+                    let opcode = mem::DupN::new(item_to_duplicate)?;
                     add_op(ops, opcode);
                 }
                 0x90..=0x9f => {

--- a/src/vm/state/memory.rs
+++ b/src/vm/state/memory.rs
@@ -82,9 +82,7 @@ impl Memory {
                 let data = SymbolicValue::new_known_value(
                     0,
                     KnownData::zero(),
-                    Provenance::UninitializedMemory {
-                        key: offset.clone(),
-                    },
+                    Provenance::UninitializedMemory,
                 );
                 MemStore {
                     data,
@@ -256,12 +254,7 @@ mod test {
                 ..
             } => {
                 assert_eq!(value, &KnownData::zero());
-                assert_eq!(
-                    provenance,
-                    &Provenance::UninitializedMemory {
-                        key: offset.clone(),
-                    }
-                );
+                assert_eq!(provenance, &Provenance::UninitializedMemory,);
             }
             _ => panic!("Test failure"),
         }

--- a/src/vm/state/mod.rs
+++ b/src/vm/state/mod.rs
@@ -120,7 +120,7 @@ mod test {
     #[test]
     fn can_record_symbolic_value() {
         let mut state = VMState::default();
-        let value = SymbolicValue::new_synthetic(0, SymbolicValueData::default());
+        let value = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
         state.record_value(value.clone());
 
         let values = state.recorded_values();
@@ -130,7 +130,7 @@ mod test {
 
     #[test]
     fn can_fork_state() -> anyhow::Result<()> {
-        let value = SymbolicValue::new_synthetic(0, SymbolicValueData::default());
+        let value = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
         let state = VMState::default();
         let mut forked_state = state.fork(78);
 

--- a/src/vm/state/storage.rs
+++ b/src/vm/state/storage.rs
@@ -76,11 +76,7 @@ impl Storage {
         target_map.entry(key.clone()).or_insert_with(|| {
             // The instruction pointer is 0 here, as the uninitialized value was created
             // when the program started. It is _not_ synthetic.
-            SymbolicValue::new_known_value(
-                0,
-                KnownData::zero(),
-                Provenance::UninitializedStorage { key: key.clone() },
-            )
+            SymbolicValue::new_known_value(0, KnownData::zero(), Provenance::UninitializedStorage)
         })
     }
 
@@ -177,10 +173,7 @@ mod test {
                 ..
             } => {
                 assert_eq!(value, &KnownData::zero());
-                assert_eq!(
-                    provenance,
-                    &Provenance::UninitializedStorage { key: key_1.clone() }
-                )
+                assert_eq!(provenance, &Provenance::UninitializedStorage)
             }
             _ => panic!("Test failure"),
         }
@@ -192,10 +185,7 @@ mod test {
                 ..
             } => {
                 assert_eq!(value, &KnownData::zero());
-                assert_eq!(
-                    provenance,
-                    &Provenance::UninitializedStorage { key: key_2.clone() }
-                )
+                assert_eq!(provenance, &Provenance::UninitializedStorage)
             }
             _ => panic!("Test failure"),
         }

--- a/src/vm/value/known_data.rs
+++ b/src/vm/value/known_data.rs
@@ -21,6 +21,6 @@ impl KnownData {
     /// Creates a known value representing zero as a 256-bit wide unsigned
     /// integer.
     pub fn zero() -> Self {
-        KnownData::UInt { value: vec![32, 0] }
+        KnownData::UInt { value: vec![0; 32] }
     }
 }


### PR DESCRIPTION
# Summary

This commit implements the executable semantics of the memory-related opcodes in terms of symbolic values. These semantics carefully manipulate the state of the `VM` in order to track what is done to given values during execution of the code.

# Details

Please take a close look at the semantics in each `execute` implementation.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
