### PR TITLE
Implement the arithmetic and logic opcodes

### DIFF
--- a/src/opcode/arithmetic.rs
+++ b/src/opcode/arithmetic.rs
@@ -1,8 +1,12 @@
 //! Opcodes that perform arithmetic operations on the EVM.
 
-#![allow(unused_variables)] // Temporary allow to suppress valid warnings for now.
-
-use crate::{opcode::Opcode, vm::VM};
+use crate::{
+    opcode::Opcode,
+    vm::{
+        value::{SymbolicValue, SymbolicValueData},
+        VM,
+    },
+};
 
 /// The `ADD` opcode performs addition.
 ///
@@ -22,7 +26,25 @@ pub struct Add;
 
 impl Opcode for Add {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Add { left: a, right: b },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -60,7 +82,25 @@ pub struct Mul;
 
 impl Opcode for Mul {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Multiply { left: a, right: b },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -98,7 +138,25 @@ pub struct Sub;
 
 impl Opcode for Sub {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Subtract { left: a, right: b },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -136,7 +194,28 @@ pub struct Div;
 
 impl Opcode for Div {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Divide {
+                dividend: a,
+                divisor:  b,
+            },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -177,7 +256,28 @@ pub struct SDiv;
 
 impl Opcode for SDiv {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::SignedDivide {
+                dividend: a,
+                divisor:  b,
+            },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -215,7 +315,28 @@ pub struct Mod;
 
 impl Opcode for Mod {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Modulo {
+                dividend: a,
+                divisor:  b,
+            },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -256,7 +377,28 @@ pub struct SMod;
 
 impl Opcode for SMod {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::SignedModulo {
+                dividend: a,
+                divisor:  b,
+            },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -300,7 +442,34 @@ pub struct AddMod;
 
 impl Opcode for AddMod {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+        let n = stack.pop()?;
+
+        // As they are semantically equivalent for the purposes of symbolic
+        // execution, we simplify this into nested add and mod.
+        let add = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Add { left: a, right: b },
+        );
+        let modulo = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Modulo {
+                dividend: add,
+                divisor:  n,
+            },
+        );
+
+        // The result gets pushed onto the stack
+        stack.push(modulo)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -344,7 +513,34 @@ pub struct MulMod;
 
 impl Opcode for MulMod {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+        let n = stack.pop()?;
+
+        // As they are semantically equivalent for the purposes of symbolic
+        // execution, we simplify this into nested add and mod.
+        let mul = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Multiply { left: a, right: b },
+        );
+        let modulo = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Modulo {
+                dividend: mul,
+                divisor:  n,
+            },
+        );
+
+        // The result gets pushed onto the stack
+        stack.push(modulo)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -382,7 +578,28 @@ pub struct Exp;
 
 impl Opcode for Exp {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Exp {
+                value:    a,
+                exponent: b,
+            },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -425,7 +642,25 @@ pub struct SignExtend;
 
 impl Opcode for SignExtend {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let x = stack.pop()?;
+
+        // Create the new value
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::SignExtend { value: a, size: x },
+        );
+
+        // Push it onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -442,5 +677,343 @@ impl Opcode for SignExtend {
 
     fn as_byte(&self) -> u8 {
         0x0b
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        opcode::{arithmetic, test_util as util, Opcode},
+        vm::value::{Provenance, SymbolicValue, SymbolicValueData},
+    };
+
+    #[test]
+    fn add_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Add;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Add { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn mul_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Mul;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Multiply { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn sub_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Sub;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Subtract { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn div_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Div;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Divide { dividend, divisor } => {
+                assert_eq!(dividend, &input_left);
+                assert_eq!(divisor, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_div_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::SDiv;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::SignedDivide { dividend, divisor } => {
+                assert_eq!(dividend, &input_left);
+                assert_eq!(divisor, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn mod_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Mod;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Modulo { dividend, divisor } => {
+                assert_eq!(dividend, &input_left);
+                assert_eq!(divisor, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_mod_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::SMod;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::SignedModulo { dividend, divisor } => {
+                assert_eq!(dividend, &input_left);
+                assert_eq!(divisor, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn add_mod_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_n = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_n.clone(),
+            input_right.clone(),
+            input_left.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::AddMod;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Modulo { dividend, divisor } => {
+                assert_eq!(divisor, &input_n);
+                assert_eq!(dividend.provenance, Provenance::Execution);
+                match &dividend.data {
+                    SymbolicValueData::Add { left, right } => {
+                        assert_eq!(left, &input_left);
+                        assert_eq!(right, &input_right);
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn mul_mod_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let input_n = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![
+            input_n.clone(),
+            input_right.clone(),
+            input_left.clone(),
+        ])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::MulMod;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Modulo { dividend, divisor } => {
+                assert_eq!(divisor, &input_n);
+                assert_eq!(dividend.provenance, Provenance::Execution);
+                match &dividend.data {
+                    SymbolicValueData::Multiply { left, right } => {
+                        assert_eq!(left, &input_left);
+                        assert_eq!(right, &input_right);
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn exp_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::Exp;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::Exp { value, exponent } => {
+                assert_eq!(value, &input_left);
+                assert_eq!(exponent, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn sign_extend_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the stack and vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = arithmetic::SignExtend;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let item = stack.read(0)?;
+        assert_eq!(item.provenance, Provenance::Execution);
+        match &item.data {
+            SymbolicValueData::SignExtend { value, size } => {
+                assert_eq!(value, &input_left);
+                assert_eq!(size, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
     }
 }

--- a/src/opcode/logic.rs
+++ b/src/opcode/logic.rs
@@ -1,8 +1,12 @@
 //! Opcodes that deal with performing boolean logic on the EVM.
 
-#![allow(unused_variables)] // Temporary allow to suppress valid warnings for now.
-
-use crate::{opcode::Opcode, vm::VM};
+use crate::{
+    opcode::Opcode,
+    vm::{
+        value::{known_data::KnownData, Provenance, SymbolicValue, SymbolicValueData},
+        VM,
+    },
+};
 
 /// The `LT` opcode performs a less-than comparison.
 ///
@@ -22,7 +26,23 @@ pub struct Lt;
 
 impl Opcode for Lt {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::LessThan { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -60,7 +80,23 @@ pub struct Gt;
 
 impl Opcode for Gt {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::GreaterThan { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -99,7 +135,23 @@ pub struct SLt;
 
 impl Opcode for SLt {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::SignedLessThan { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -138,7 +190,23 @@ pub struct SGt;
 
 impl Opcode for SGt {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::SignedGreaterThan { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -176,7 +244,23 @@ pub struct Eq;
 
 impl Opcode for Eq {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Equals { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -213,7 +297,22 @@ pub struct IsZero;
 
 impl Opcode for IsZero {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let number = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::IsZero { number },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -251,7 +350,23 @@ pub struct And;
 
 impl Opcode for And {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::And { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -289,7 +404,23 @@ pub struct Or;
 
 impl Opcode for Or {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Or { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -327,7 +458,23 @@ pub struct Xor;
 
 impl Opcode for Xor {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let a = stack.pop()?;
+        let b = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Xor { left: a, right: b },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -364,7 +511,22 @@ pub struct Not;
 
 impl Opcode for Not {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let value = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Not { bool: value },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -408,7 +570,69 @@ pub struct Byte;
 
 impl Opcode for Byte {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and the env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands
+        let offset = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Construct the constants
+        let const_0x08 = SymbolicValue::new_known_value(
+            instruction_pointer,
+            KnownData::UInt {
+                value: 0x08u8.to_le_bytes().to_vec(),
+            },
+            Provenance::Bytecode,
+        );
+        let const_0xf8 = SymbolicValue::new_known_value(
+            instruction_pointer,
+            KnownData::UInt {
+                value: 0xf8u8.to_le_bytes().to_vec(),
+            },
+            Provenance::Bytecode,
+        );
+        let const_0xff = SymbolicValue::new_known_value(
+            instruction_pointer,
+            KnownData::UInt {
+                value: 0xffu8.to_le_bytes().to_vec(),
+            },
+            Provenance::Bytecode,
+        );
+
+        // Construct the intermediates
+        let offset_times_0x08 = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Multiply {
+                left:  offset,
+                right: const_0x08,
+            },
+        );
+        let shift = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::Subtract {
+                left:  const_0xf8,
+                right: offset_times_0x08,
+            },
+        );
+        let shifted = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::RightShift { value, shift },
+        );
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::And {
+                left:  shifted,
+                right: const_0xff,
+            },
+        );
+
+        // Push the result onto the stack
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -453,7 +677,23 @@ pub struct Shl;
 
 impl Opcode for Shl {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let shift = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::LeftShift { shift, value },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -499,7 +739,23 @@ pub struct Shr;
 
 impl Opcode for Shr {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let shift = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::RightShift { shift, value },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -547,7 +803,23 @@ pub struct Sar;
 
 impl Opcode for Sar {
     fn execute(&self, vm: &mut VM) -> anyhow::Result<()> {
-        unimplemented!()
+        // Get the stack and env data
+        let instruction_pointer = vm.instruction_pointer()?;
+        let stack = vm.stack()?;
+
+        // Get the operands from the stack
+        let shift = stack.pop()?;
+        let value = stack.pop()?;
+
+        // Construct the result and push it to the stack
+        let result = SymbolicValue::new_from_execution(
+            instruction_pointer,
+            SymbolicValueData::ArithmeticRightShift { shift, value },
+        );
+        stack.push(result)?;
+
+        // Done, so return ok
+        Ok(())
     }
 
     fn min_gas_cost(&self) -> usize {
@@ -564,5 +836,471 @@ impl Opcode for Sar {
 
     fn as_byte(&self) -> u8 {
         0x1d
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        opcode::{logic, test_util as util, Opcode},
+        vm::value::{known_data::KnownData, Provenance, SymbolicValue, SymbolicValueData},
+    };
+
+    #[test]
+    fn lt_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Lt;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::LessThan { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn gt_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Gt;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::GreaterThan { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_lt_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::SLt;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::SignedLessThan { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn s_gt_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::SGt;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::SignedGreaterThan { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn eq_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Eq;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::Equals { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn is_zero_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let operand = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![operand.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::IsZero;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::IsZero { number } => {
+                assert_eq!(number, &operand);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn and_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::And;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::And { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn or_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Or;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::Or { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn xor_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Xor;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::Xor { left, right } => {
+                assert_eq!(left, &input_left);
+                assert_eq!(right, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn not_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let operand = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let mut vm = util::new_vm_with_values_on_stack(vec![operand.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Not;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::Not { bool } => {
+                assert_eq!(bool, &operand);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn byte_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_offset = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_value = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_value.clone(), input_offset.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Byte;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+
+        // At the top level the value should be a logical conjunction
+        match &result.data {
+            SymbolicValueData::And { left, right } => {
+                assert_eq!(left.provenance, Provenance::Execution);
+                assert_eq!(right.provenance, Provenance::Bytecode);
+
+                // The right operand should be a constant 0xff
+                match &right.data {
+                    SymbolicValueData::KnownData { value, .. } => {
+                        assert_eq!(
+                            value,
+                            &KnownData::UInt {
+                                value: 0xffu8.to_le_bytes().to_vec(),
+                            }
+                        );
+                    }
+                    _ => panic!("Invalid payload"),
+                }
+
+                // The left operand should be an unsigned right shift
+                match &left.data {
+                    SymbolicValueData::RightShift { value, shift } => {
+                        assert_eq!(shift.provenance, Provenance::Execution);
+
+                        // The value should come from the inputs
+                        assert_eq!(value, &input_value);
+
+                        // The shift size is computed
+                        match &shift.data {
+                            SymbolicValueData::Subtract { left, right } => {
+                                assert_eq!(left.provenance, Provenance::Bytecode);
+                                assert_eq!(right.provenance, Provenance::Execution);
+
+                                // The left operand is a constant 0xf8
+                                match &left.data {
+                                    SymbolicValueData::KnownData { value, .. } => {
+                                        assert_eq!(
+                                            value,
+                                            &KnownData::UInt {
+                                                value: 0xf8u8.to_le_bytes().to_vec(),
+                                            }
+                                        )
+                                    }
+                                    _ => panic!("Invalid payload"),
+                                }
+
+                                // The right operand is computed
+                                match &right.data {
+                                    SymbolicValueData::Multiply { left, right } => {
+                                        assert_eq!(right.provenance, Provenance::Bytecode);
+
+                                        // The left is the input offset
+                                        assert_eq!(left, &input_offset);
+
+                                        // The right is a constant 0x08
+                                        match &right.data {
+                                            SymbolicValueData::KnownData { value, .. } => {
+                                                assert_eq!(
+                                                    value,
+                                                    &KnownData::UInt {
+                                                        value: 0x08u8.to_le_bytes().to_vec(),
+                                                    }
+                                                )
+                                            }
+                                            _ => panic!("Invalid payload"),
+                                        }
+                                    }
+                                    _ => panic!("Invalid payload"),
+                                }
+                            }
+                            _ => panic!("Invalid payload"),
+                        }
+                    }
+                    _ => panic!("Invalid payload"),
+                }
+            }
+            _ => panic!("Invalid payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn shl_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Shl;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::LeftShift { shift, value } => {
+                assert_eq!(shift, &input_left);
+                assert_eq!(value, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn shr_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Shr;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::RightShift { shift, value } => {
+                assert_eq!(shift, &input_left);
+                assert_eq!(value, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn sar_manipulates_stack() -> anyhow::Result<()> {
+        // Prepare the vm
+        let input_left = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
+        let input_right = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
+        let mut vm =
+            util::new_vm_with_values_on_stack(vec![input_right.clone(), input_left.clone()])?;
+
+        // Prepare and run the opcode
+        let opcode = logic::Sar;
+        opcode.execute(&mut vm)?;
+
+        // Inspect the stack
+        let stack = vm.stack()?;
+        assert_eq!(stack.depth(), 1);
+        let result = stack.read(0)?;
+        assert_eq!(result.provenance, Provenance::Execution);
+        match &result.data {
+            SymbolicValueData::ArithmeticRightShift { shift, value } => {
+                assert_eq!(shift, &input_left);
+                assert_eq!(value, &input_right);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
     }
 }

--- a/src/opcode/mod.rs
+++ b/src/opcode/mod.rs
@@ -93,3 +93,33 @@ where
 
 /// A type for an [`Opcode`] that is dynamically dispatched.
 pub type DynOpcode = Rc<dyn Opcode>;
+
+#[cfg(test)]
+mod test_util {
+    use crate::vm::{instructions::InstructionStream, value::BoxedVal, Config, VM};
+
+    /// Constructs a new virtual machine with the provided `values` pushed
+    /// onto its stack in order.
+    ///
+    /// This means that the last item in `values` will be put on the top of
+    /// the stack.
+    pub fn new_vm_with_values_on_stack(values: Vec<BoxedVal>) -> anyhow::Result<VM> {
+        // We don't actually care what these are for this test, so we just have
+        // _something_ long enough to account for what is going on.
+        let bytes: Vec<u8> = vec![
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x10, 0x11,
+        ];
+
+        let instructions = InstructionStream::try_from(bytes.as_slice())?;
+        let config = Config::default();
+
+        let mut vm = VM::new(instructions, config)?;
+        let stack = vm.stack()?;
+
+        values.into_iter().for_each(|val| {
+            stack.push(val).expect("Failed to insert value into stack");
+        });
+
+        Ok(vm)
+    }
+}

--- a/src/vm/state/memory.rs
+++ b/src/vm/state/memory.rs
@@ -291,21 +291,21 @@ mod test {
         );
         let prod = SymbolicValue::new_synthetic(
             3,
-            SymbolicValueData::Mul {
+            SymbolicValueData::Multiply {
                 left:  left.clone(),
                 right: right.clone(),
             },
         );
         let sub = SymbolicValue::new_synthetic(
             4,
-            SymbolicValueData::Sub {
+            SymbolicValueData::Subtract {
                 left:  left.clone(),
                 right: right.clone(),
             },
         );
         let div = SymbolicValue::new_synthetic(
             5,
-            SymbolicValueData::Div {
+            SymbolicValueData::Divide {
                 dividend: left,
                 divisor:  right,
             },

--- a/src/vm/state/mod.rs
+++ b/src/vm/state/mod.rs
@@ -142,12 +142,12 @@ mod test {
         forked_state.stack.push(value.clone())?;
         forked_state.memory.store(value.clone(), value.clone());
         forked_state.storage.store(value.clone(), value);
-        assert_eq!(forked_state.stack.size(), 1);
+        assert_eq!(forked_state.stack.depth(), 1);
         assert_eq!(forked_state.memory.entry_count(), 1);
         assert_eq!(forked_state.storage.entry_count(), 1);
 
         // Without modifying the other.
-        assert_eq!(state.stack.size(), 0);
+        assert_eq!(state.stack.depth(), 0);
         assert_eq!(state.memory.entry_count(), 0);
         assert_eq!(state.storage.entry_count(), 0);
 

--- a/src/vm/state/stack.rs
+++ b/src/vm/state/stack.rs
@@ -108,14 +108,14 @@ impl Stack {
         Ok(())
     }
 
-    /// Gets the current size of the stack.
-    pub fn size(&self) -> usize {
+    /// Gets the current depth of the stack.
+    pub fn depth(&self) -> usize {
         self.data.len()
     }
 
     /// Checks if the stack is empty.
     pub fn is_empty(&self) -> bool {
-        self.size() == 0
+        self.depth() == 0
     }
 
     /// Checks if a frame exists at the provided `depth`.
@@ -178,7 +178,7 @@ mod test {
     #[test]
     fn can_construct_new_stack() {
         let stack = Stack::new();
-        assert_eq!(stack.size(), 0);
+        assert_eq!(stack.depth(), 0);
     }
 
     #[test]
@@ -243,9 +243,9 @@ mod test {
     #[test]
     fn can_dup_existing_item() -> anyhow::Result<()> {
         let mut stack = new_stack_with_items(10)?;
-        assert_eq!(stack.size(), 10);
+        assert_eq!(stack.depth(), 10);
         stack.dup(3)?;
-        assert_eq!(stack.size(), 11);
+        assert_eq!(stack.depth(), 11);
 
         Ok(())
     }
@@ -303,11 +303,11 @@ mod test {
     #[test]
     fn can_get_size_for_stack() -> anyhow::Result<()> {
         let empty = Stack::default();
-        assert_eq!(empty.size(), 0);
+        assert_eq!(empty.depth(), 0);
         assert!(empty.is_empty());
 
         let non_empty = new_stack_with_items(100)?;
-        assert_eq!(non_empty.size(), 100);
+        assert_eq!(non_empty.depth(), 100);
         assert!(!non_empty.is_empty());
 
         Ok(())

--- a/src/vm/value/mod.rs
+++ b/src/vm/value/mod.rs
@@ -58,7 +58,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
-    pub fn new_from_program(instruction_pointer: u32, data: SymbolicValueData) -> Box<Self> {
+    pub fn new_from_execution(instruction_pointer: u32, data: SymbolicValueData) -> Box<Self> {
         Self::new(instruction_pointer, data, Provenance::Execution)
     }
 
@@ -144,28 +144,22 @@ pub enum SymbolicValueData {
     Add { left: BoxedVal, right: BoxedVal },
 
     /// Multiplication of symbolic values.
-    Mul { left: BoxedVal, right: BoxedVal },
+    Multiply { left: BoxedVal, right: BoxedVal },
 
     /// Subtraction of symbolic values.
-    Sub { left: BoxedVal, right: BoxedVal },
+    Subtract { left: BoxedVal, right: BoxedVal },
 
     /// Division of symbolic values.
-    Div { dividend: BoxedVal, divisor: BoxedVal },
+    Divide { dividend: BoxedVal, divisor: BoxedVal },
 
     /// Signed division of symbolic values.
-    SDiv { dividend: BoxedVal, divisor: BoxedVal },
+    SignedDivide { dividend: BoxedVal, divisor: BoxedVal },
 
     /// Modulo of symbolic values.
-    Mod { dividend: BoxedVal, divisor: BoxedVal },
+    Modulo { dividend: BoxedVal, divisor: BoxedVal },
 
     /// Signed modulo of symbolic values.
-    SMod { dividend: BoxedVal, divisor: BoxedVal },
-
-    /// Addition followed by modulo.
-    AddMod { left: BoxedVal, right: BoxedVal, exponent: BoxedVal },
-
-    /// Multiplication followed by modulo.
-    MulMod { left: BoxedVal, right: BoxedVal, exponent: BoxedVal },
+    SignedModulo { dividend: BoxedVal, divisor: BoxedVal },
 
     /// Exponentiation of symbolic values.
     Exp { value: BoxedVal, exponent: BoxedVal },
@@ -290,19 +284,19 @@ pub enum SymbolicValueData {
     SelfDestruct { target: BoxedVal },
 
     /// Less than for symbolic values.
-    Lt { left: BoxedVal, right: BoxedVal },
+    LessThan { left: BoxedVal, right: BoxedVal },
 
     /// Greater than for symbolic values.
-    Gt { left: BoxedVal, right: BoxedVal },
+    GreaterThan { left: BoxedVal, right: BoxedVal },
 
     /// Less than for symbolic values where the values are signed.
-    SLt { left: BoxedVal, right: BoxedVal },
+    SignedLessThan { left: BoxedVal, right: BoxedVal },
 
     /// Greater than for symbolic values where the values are signed.
-    SGt { left: BoxedVal, right: BoxedVal },
+    SignedGreaterThan { left: BoxedVal, right: BoxedVal },
 
     /// Equality for symbolic values.
-    Eq { left: BoxedVal, right: BoxedVal },
+    Equals { left: BoxedVal, right: BoxedVal },
 
     /// Checking if a symbolic value is zero.
     IsZero { number: BoxedVal },
@@ -319,17 +313,14 @@ pub enum SymbolicValueData {
     /// Negation of a symbolic value.
     Not { bool: BoxedVal },
 
-    /// Gets a byte from a word.
-    Byte { offset: BoxedVal, value: BoxedVal },
-
     /// Left shift with symbolic values.
-    Shl { shift: BoxedVal, value: BoxedVal },
+    LeftShift { shift: BoxedVal, value: BoxedVal },
 
     /// Right shift with symbolic values.
-    Shr { shift: BoxedVal, value: BoxedVal },
+    RightShift { shift: BoxedVal, value: BoxedVal },
 
     /// Signed right shift with symbolic values.
-    Sar { shift: BoxedVal, value: BoxedVal },
+    ArithmeticRightShift { shift: BoxedVal, value: BoxedVal },
 
     /// Loading the data at `offset` for `size` in the call data.
     CallData { offset: BoxedVal, size: BoxedVal },
@@ -435,7 +426,7 @@ mod test {
     fn equality_includes_provenance() {
         let id = Uuid::new_v4();
         let data = SymbolicValueData::Value { id };
-        let value_1 = SymbolicValue::new_from_program(0, data.clone());
+        let value_1 = SymbolicValue::new_from_execution(0, data.clone());
         let value_2 = SymbolicValue::new_synthetic(1, data);
 
         assert_ne!(value_1, value_2);


### PR DESCRIPTION
# Summary

This commit provides concrete implementations of the symbolic semantics of the arithmetic and logical set of opcodes. It is accompanied by comprehensive unit tests that ensure that these function as they should.

# Details

Please pay close attention to the semantics of the opcodes.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
