### PR TITLE
Fix instruction tracking

### DIFF
--- a/src/opcode/memory.rs
+++ b/src/opcode/memory.rs
@@ -748,7 +748,8 @@ impl Opcode for Pop {
         let mut stack = vm.stack_handle()?;
 
         // Pop the value from the stack.
-        stack.pop()?;
+        let value = stack.pop()?;
+        vm.state()?.record_value(value);
 
         // Done, so return ok
         Ok(())

--- a/src/vm/data.rs
+++ b/src/vm/data.rs
@@ -76,7 +76,7 @@ impl VisitedOpcodes {
     ///
     /// Returns [`Err`] if the provided `instruction_pointer` is out of bounds
     /// in the instruction stream.
-    pub fn visited(&mut self, instruction_pointer: u32) -> execution::Result<bool> {
+    pub fn visited(&self, instruction_pointer: u32) -> execution::Result<bool> {
         if instruction_pointer < self.instructions_len {
             Ok(self.data.contains(&instruction_pointer))
         } else {

--- a/src/vm/instructions/mod.rs
+++ b/src/vm/instructions/mod.rs
@@ -108,7 +108,12 @@ impl<'a> TryFrom<&'a [u8]> for InstructionStream {
 
     fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
         let instructions = Rc::new(parser::parse(value)?);
-        Ok(Self { instructions })
+        let result = Self { instructions };
+
+        // An assertion that will be disabled in production builds, but a good sanity
+        // check that disassembly didn't go wrong
+        assert_eq!(result.as_bytecode().as_slice(), value);
+        Ok(result)
     }
 }
 
@@ -139,6 +144,12 @@ impl TryFrom<&str> for InstructionStream {
 impl From<InstructionStream> for Vec<u8> {
     fn from(value: InstructionStream) -> Self {
         value.instructions.iter().flat_map(|opcode| opcode.encode()).collect()
+    }
+}
+
+impl From<InstructionStream> for Rc<Vec<DynOpcode>> {
+    fn from(value: InstructionStream) -> Self {
+        value.instructions
     }
 }
 

--- a/src/vm/thread.rs
+++ b/src/vm/thread.rs
@@ -83,10 +83,11 @@ impl VMThread {
     pub fn gas_usage(&self) -> usize {
         self.gas_usage
     }
+}
 
-    /// Consumes the thread to produce its state.
-    pub fn into_state(self) -> VMState {
-        self.state
+impl From<VMThread> for VMState {
+    fn from(value: VMThread) -> Self {
+        value.state
     }
 }
 
@@ -99,7 +100,7 @@ mod test {
         let instruction_stream = InstructionStream::try_from(
             vec![0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06].as_slice(),
         )?;
-        let state = VMState::default();
+        let state = VMState::new_at_start(instruction_stream.len() as u32);
         let execution_thread = instruction_stream.new_thread(0)?;
         let mut vm_thread = VMThread::new(state, execution_thread);
 


### PR DESCRIPTION
# Summary

Previously, instruction visitation was tracked at the level of the symbolic virtual machine. This was incorrect, as it would cause execution to bail out in valid sequences due to a different thread of execution having already visited instructions.

Now, visitation is tracked at the level of the individual thread, and is forked when the thread is forked, thus preventing a given sequence from re-visiting something (and hence looping infinitely), but also allowing individual sequences to visit all the instructions that they need.

# Details

Please check my logic here, both mentally and with actual contracts. I've tried this on a simple one with a loop and we don't get an infinite loop, but more complex contracts would be good.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
