### PR TITLE
Implement the initial skeleton for the Unifier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ publish = false
 
 # Build dependencies.
 [dependencies]
-anyhow = { version = "1.0.71", features = ["backtrace"] }
+bimap = "0.6.3"
 derivative = "2.2.0"
 downcast-rs = "1.2.0"
 ethnum = "1.3.2"
@@ -34,12 +34,13 @@ hex = "0.4.3"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 thiserror = "1.0.40"
-uuid = { version = "1.3.2", features = ["v4", "fast-rng", "macro-diagnostics"]}
+uuid = { version = "1.3.2", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 # Dev dependencies.
 #
 # These are the dependencies required purely for internal development of the library such as testing or benchmarking.
 [dev-dependencies]
+anyhow = { version = "1.0.71", features = ["backtrace"] }
 project-root = "0.2.2"
 rand = "0.8.5"
 

--- a/src/analyzer/state.rs
+++ b/src/analyzer/state.rs
@@ -2,22 +2,26 @@
 
 use std::fmt::Debug;
 
-use crate::vm::{instructions::InstructionStream, ExecutionResult, VM};
+use crate::{
+    unifier::Unifier,
+    vm::{instructions::InstructionStream, ExecutionResult, VM},
+    StorageLayout,
+};
 
 /// A marker trait that says that the type implementing it is an analyzer state.
 pub trait State
 where
-    Self: Clone + Debug + Sized,
+    Self: Debug + Sized,
 {
 }
 
 /// The initial state for the analyzer.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct HasContract;
 impl State for HasContract {}
 
 /// The analyzer has successfully disassembled the bytecode.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DisassemblyComplete {
     /// The disassembled bytecode for the contract being analyzed.
     pub bytecode: InstructionStream,
@@ -26,15 +30,30 @@ impl State for DisassemblyComplete {}
 
 /// The analyzer has prepared the virtual machine to symbolically execute the
 /// contract's bytecode.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct VMReady {
     pub vm: VM,
 }
 impl State for VMReady {}
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ExecutionComplete {
     /// The results from executing the bytecode.
     pub execution_result: ExecutionResult,
 }
 impl State for ExecutionComplete {}
+
+/// The analyzer has prepared the unifier to perform its processes.
+#[derive(Debug)]
+pub struct UnifierReady {
+    pub unifier: Unifier,
+}
+impl State for UnifierReady {}
+
+/// The analyzer has completed its unification and inference process, and is now
+/// ready to provide the concrete storage layout.
+#[derive(Debug)]
+pub struct UnificationComplete {
+    pub layout: StorageLayout,
+}
+impl State for UnificationComplete {}

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -39,3 +39,6 @@ pub const PUSH_OPCODE_MAX_BYTES: u8 = 32;
 
 /// The maximum stack depth for the EVM.
 pub const MAXIMUM_STACK_DEPTH: usize = 1024;
+
+/// The width of word on the EVM in bits.
+pub const WORD_SIZE: usize = 256;

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -11,8 +11,7 @@
 pub mod container;
 pub mod disassembly;
 pub mod execution;
-
-use std::rc::Rc;
+pub mod unification;
 
 use thiserror::Error;
 
@@ -39,17 +38,19 @@ pub enum Error {
     #[error(transparent)]
     Execution(#[from] execution::Error),
 
-    /// Unknown errors, usually from the dependencies of the library.
-    ///
-    /// It is wrapped in an [`Rc`] to ensure that it can be cloned like the
-    /// other error types in this interface error.
+    /// Errors from the unification subsystem of the library.
     #[error(transparent)]
-    Other(Rc<anyhow::Error>),
+    Unification(#[from] unification::Error),
+
+    /// An unknown error, represented as a string.
+    #[error("Unknown Error: {_0:?}")]
+    Other(String),
 }
 
-impl From<anyhow::Error> for Error {
-    fn from(value: anyhow::Error) -> Self {
-        Self::Other(Rc::new(value))
+impl Error {
+    /// Constructs an unknown error with the provided `message`.
+    pub fn other(message: impl Into<String>) -> Self {
+        Self::Other(message.into())
     }
 }
 

--- a/src/error/unification.rs
+++ b/src/error/unification.rs
@@ -1,0 +1,36 @@
+//! This module contains errors pertaining to the unification of typing evidence
+//! gathered during symbolic execution of the bytecode.
+
+use thiserror::Error;
+
+use crate::{error::container, vm::value::SymbolicValue};
+
+/// Errors that occur during unification and type inference process in the
+/// [`crate::unifier::Unifier`].
+#[derive(Clone, Debug, Eq, Error, PartialEq)]
+pub enum Error {
+    #[error("Invalid tree encountered during unification: {value:?}")]
+    InvalidTree { value: SymbolicValue },
+}
+
+/// Make it possible to attach locations to these errors.
+impl container::Locatable for Error {
+    type Located = LocatedError;
+
+    fn locate(self, instruction_pointer: u32) -> Self::Located {
+        container::Located {
+            location: instruction_pointer,
+            payload:  self,
+        }
+    }
+}
+
+/// A unification error with an associated location in the bytecode.
+pub type LocatedError = container::Located<Error>;
+
+/// A container of unification errors used for aggregation of errors during
+/// unification.
+pub type Errors = container::Errors<LocatedError>;
+
+/// The result type for methods that may have unification errors.
+pub type Result<T> = std::result::Result<T, Errors>;

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,4 +3,5 @@
 //! It currently only contains placeholder types.
 
 /// The most-concrete layout discovered for the input contract.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StorageLayout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,9 @@
 //!    possible code paths that can influence the type of a storage location.
 //! 3. For each [`vm::value::SymbolicValue`], the [`vm::VM`] collects an
 //!    execution tree that provides evidence as to the type of that variable.
-//! 4. The [`unifier::Unifier`] takes those execution trees as evidence,
-//!    and combines the implications through the use of
-//!    [`unifier::implication::Set`]s to resolve the most concretely-known type
-//!    of the symbolic value in a form of usage-based type inference.
+//! 4. The [`unifier::Unifier`] takes those execution trees as evidence, and
+//!    performs a process of re-sugaring, heuristic evidence discovery, and
+//!    subsequent unification to discover the types in the program.
 //! 5. The types that are associated with storage slots are taken and written to
 //!    a [`StorageLayout`] that can then be output.
 

--- a/src/opcode/logic.rs
+++ b/src/opcode/logic.rs
@@ -521,7 +521,7 @@ impl Opcode for Not {
         // Construct the result and push it to the stack
         let result = SymbolicValue::new_from_execution(
             instruction_pointer,
-            SymbolicValueData::Not { bool: value },
+            SymbolicValueData::Not { value },
         );
         stack.push(result)?;
 
@@ -1105,8 +1105,8 @@ mod test {
         let result = stack.read(0)?;
         assert_eq!(result.provenance, Provenance::Execution);
         match &result.data {
-            SymbolicValueData::Not { bool } => {
-                assert_eq!(bool, &operand);
+            SymbolicValueData::Not { value } => {
+                assert_eq!(value, &operand);
             }
             _ => panic!("Incorrect payload"),
         }

--- a/src/unifier/abi.rs
+++ b/src/unifier/abi.rs
@@ -1,58 +1,23 @@
-//! This file contains information about the ABI types of the EVM.
+//! This module contains the definition of the solidity ABI types that the
+//! analyzer is currently capable of dealing with.
 
 use ethnum::U256;
 
-// TODO [Ara] Heuristic as a function from `SymbolicValue` to `Type`, and they
-//   get fed every terminal symbolic value.
-
-// TODO [Ara] Run it on each terminal value and combine their results via the
-//   algebra.
-
-// TODO [Ara] How do we abstract the traversal patterns?
-
-// TODO [Ara] Fuzzy logic.
-
-// TODO [Ara] Negation in the algebra. Make the algebra constructed lazily and
-//   then evaluated.
-
-/// The type representations that this analysis can figure out.
-///
-/// These types span the gamut from types that are concretely resolved to EVM
-/// types, to those that very little (or nothing) is known about.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Type {
-    /// A type that has been concretely resolved to an EVM type.
-    ConcreteType { ty: AbiType },
-
-    /// A type that is used as a numeric.
-    Numeric,
-
-    /// A type that is known to have a fixed width and be unsigned.
-    UnsignedFixedWidth { width: u16 },
-
-    /// A type that is known to have a fixed width and be signed.
-    SignedFixedWidth { width: u16 },
-
-    /// A type known to be a fixed-length array but not with a known element
-    /// type.
-    UnknownFixedArray { length: U256 },
-
-    /// A dynamic array with unknown element type.
-    UnknownDynamicArray,
-
-    /// The type of a value where nothing is known about the type other than its
-    /// existence.
-    Any,
-}
-
 /// Concretely known Solidity ABI types.
+///
+/// # Invariants
+///
+/// Each individual variant in the enum describes the invariants placed upon it.
+/// It is the responsibility of the code constructing these values to ensure
+/// that the invariants are satisfied. Code utilising them will assume that the
+/// data has been correctly constructed.
 ///
 /// # Note
 ///
 /// Solidity supports a `fixed` and `ufixed` type in the ABI, but the language
 /// support for them is lacking. For that reason we do not include them here for
 /// now.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AbiType {
     /// Unsigned integers of a given `size` in bits, where `8 < size <= 256 &&
     /// size % 8 == 0`.

--- a/src/unifier/expression.rs
+++ b/src/unifier/expression.rs
@@ -1,0 +1,82 @@
+//! This file contains the definition of the "type expression", which lets us
+//! build expressions that describe the type of a value.
+//!
+//! It is intentionally kept separate from the [`crate::unifier::state`] to
+//! ensure that you cannot create new type variables for it.
+
+use crate::{
+    constant::WORD_SIZE,
+    unifier::{abi::AbiType, state::TypeVariable},
+};
+
+/// The pieces of evidence that can be established through use of heuristics.
+///
+/// These types are combined through use of a conflict resolver that tries to
+/// discover non-conflicting patterns of evidence in the evidence for each
+/// value. It is this process that produces the best-known types for the storage
+/// slots.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum TypeExpression {
+    /// A type that has been concretely resolved to an EVM type.
+    ConcreteType { ty: AbiType },
+
+    /// A representation of the possibly-unbound type of an expression.
+    Variable { id: TypeVariable },
+
+    /// A word, with `width` and potential `signed`ness.
+    Word {
+        /// The width of the word in bits.
+        ///
+        /// Defaults to [`WORD_SIZE`].
+        width: usize,
+
+        /// Whether the word is used as signed.
+        ///
+        /// Set to [`None`] if the signedness is unknown. Otherwise set to
+        /// `true` if signed, and `false` if unsigned.
+        signed: Option<bool>,
+    },
+
+    /// A mapping composite type with `key` type and `value` type.
+    Mapping { key: BoxedTypeExpr, value: BoxedTypeExpr },
+
+    /// A dynamic array containing items with the type of `element`.
+    DynamicArray { element: BoxedTypeExpr },
+
+    /// A static array containing items of type `element` and with `length`.
+    FixedArray { element: BoxedTypeExpr, length: usize },
+}
+
+impl TypeExpression {
+    /// Constructs a word with the default width of [`WORD_SIZE`] bits and
+    /// unknown signedness.
+    pub fn default_word() -> Self {
+        let width = WORD_SIZE;
+        let signed = None;
+        Self::Word { width, signed }
+    }
+}
+
+/// Evidence, but indirect.
+pub type BoxedTypeExpr = Box<TypeExpression>;
+
+/// A vector of typing judgements.
+pub type TypeExprVec = Vec<TypeExpression>;
+
+#[cfg(test)]
+mod test {
+    use crate::{constant::WORD_SIZE, unifier::expression::TypeExpression};
+
+    #[test]
+    pub fn default_word_has_width_word_size() {
+        let expr = TypeExpression::default_word();
+
+        match expr {
+            TypeExpression::Word { width, signed } => {
+                assert_eq!(width, WORD_SIZE);
+                assert!(signed.is_none());
+            }
+            _ => panic!("Incorrect variant for default word"),
+        }
+    }
+}

--- a/src/unifier/implication.rs
+++ b/src/unifier/implication.rs
@@ -1,7 +1,0 @@
-//! This module contains the implementation of the implication [`Set`] type for
-//! the [`super::Unifier`], as well as a set of supporting types and utilities.
-
-/// The `Set` contains evidence items as to the type of a
-/// [`crate::vm::value::SymbolicValue`].
-#[derive(Debug)]
-pub struct Set;

--- a/src/unifier/mod.rs
+++ b/src/unifier/mod.rs
@@ -1,15 +1,121 @@
 //! This module contains the [`Unifier`] and related utilities.
 
-pub mod implication;
-pub mod types;
+use crate::{
+    error::unification::{Errors, Result},
+    unifier::{state::UnifierState, sugar::ReSugarPasses},
+    vm::{value::BoxedVal, ExecutionResult},
+};
 
-/// The `Unifier` is responsible for combining the evidence as to the type of a
-/// storage variable, in the form of [`implication::Set`]s, to discover the most
-/// concretely-known type for that variable.
-#[derive(Debug)]
-pub struct Unifier;
-
-// TODO [Ara] Needs to de-duplicate trees as some will be the same.
+pub mod abi;
+pub mod expression;
+pub mod state;
+pub mod sugar;
 
 // TODO [Ara] Precomputed keccaks for the early storage slots to help with
 //   recognition of constants. With arrays.
+
+// TODO [Ara] Config with the ability to take additional externally-defined
+//   heuristics.
+
+/// The `Unifier` is responsible for combining the evidence as to the type of a
+/// storage variable.
+#[derive(Debug)]
+pub struct Unifier {
+    /// The configuration of the unifier.
+    config: Config,
+
+    /// The results of executing the symbolic virtual machine on the contract's
+    /// bytecode.
+    execution_result: ExecutionResult,
+
+    /// The internal state for the unifier,
+    state: UnifierState,
+}
+
+impl Unifier {
+    /// Constructs a new unifier configured by the provided `config` and working
+    /// on the data in the provided `execution_result`.
+    pub fn new(config: Config, execution_result: ExecutionResult) -> Self {
+        let state = UnifierState::new();
+        Self {
+            config,
+            execution_result,
+            state,
+        }
+    }
+
+    /// Executes the re-sugaring passes on all of the available symbolic values,
+    /// potentially transforming them, and then returns the associated type
+    /// variables for each expression.
+    ///
+    /// Executing this method inserts all of the transformed values into the
+    /// state of the unifier.
+    pub fn re_sugar(&mut self) -> Result<Vec<BoxedVal>> {
+        let mut new_values = Vec::new();
+        let mut errors = Errors::new();
+        for value in self.execution_result.all_values() {
+            match self.config.sugar_passes.run(value.constant_fold(), &mut self.state) {
+                Ok(v) => new_values.push(v),
+                Err(e) => errors.add_many_located(e),
+            }
+        }
+
+        if !errors.is_empty() {
+            Err(errors)
+        } else {
+            Ok(new_values)
+        }
+    }
+
+    // TODO [Ara] Discover storage slots in re-sugaring
+    // TODO [Ara] Assign type variables
+    // TODO [Ara] Run heuristics
+    // TODO [Ara] Unify
+
+    /// Gets the unifier's configuration to allow inspection.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Gets the execution result over which the unifier is operating.
+    pub fn execution_result(&self) -> &ExecutionResult {
+        &self.execution_result
+    }
+
+    /// Gets the state of the unifier.
+    pub fn state(&self) -> &UnifierState {
+        &self.state
+    }
+
+    /// Mutably gets the state of the unifier.
+    ///
+    /// # Safety
+    ///
+    /// This function should only be used to alter the unifier state if you
+    /// clearly understand the operations this entails, and the invariants that
+    /// might be violated.
+    pub unsafe fn state_mut(&mut self) -> &mut UnifierState {
+        &mut self.state
+    }
+}
+
+/// The unifier's configuration, allowing its behaviour to be configured
+/// externally.
+#[derive(Debug)]
+pub struct Config {
+    /// The re-sugaring passes that will be run.
+    ///
+    /// Defaults to [`ReSugarPasses::default()`].
+    pub sugar_passes: ReSugarPasses,
+}
+
+/// Creates a default unifier configuration.
+impl Default for Config {
+    fn default() -> Self {
+        let sugar_passes = ReSugarPasses::default();
+        Self { sugar_passes }
+    }
+}
+
+#[cfg(test)]
+mod test {}

--- a/src/unifier/state.rs
+++ b/src/unifier/state.rs
@@ -1,0 +1,192 @@
+//! This module contains the definition of the unifier state and other
+//! supporting types.
+
+use std::collections::HashMap;
+
+use bimap::BiMap;
+use uuid::Uuid;
+
+use crate::{
+    unifier::expression::{TypeExprVec, TypeExpression},
+    vm::value::BoxedVal,
+};
+
+/// The internal state of the unifier, used to track modifications to typing
+/// judgements as it runs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnifierState {
+    /// A mapping from symbolic values (which may be children of other symbolic
+    /// values) to their corresponding type variables.
+    ///
+    /// This mapping is bijective as there should be a bijection between
+    /// and type variables.
+    expressions_and_vars: BiMap<BoxedVal, TypeVariable>,
+
+    /// A mapping from type variables to their corresponding typing judgements.
+    type_expressions: HashMap<TypeVariable, TypeExprVec>,
+}
+
+impl UnifierState {
+    /// Constructs a new, empty state for the unifier.
+    pub fn new() -> Self {
+        let expressions_and_vars = BiMap::new();
+        let type_expressions = HashMap::new();
+        Self {
+            expressions_and_vars,
+            type_expressions,
+        }
+    }
+
+    /// Adds a symbolic `value` to the state, associating a fresh type variable
+    /// with it.
+    ///
+    /// If `value` already exists in the state, then the existing type variable
+    /// is returned. If not, a fresh type variable is associated with the value
+    /// and returned.
+    pub fn add(&mut self, value: BoxedVal) -> TypeVariable {
+        match self.expressions_and_vars.get_by_left(&value) {
+            Some(v) => *v,
+            None => {
+                let type_var = TypeVariable::fresh();
+                self.expressions_and_vars.insert(value, type_var);
+                self.type_expressions.entry(type_var).or_insert(vec![]);
+                type_var
+            }
+        }
+    }
+
+    /// Adds the provided `expression` to the typing expressions for the
+    /// provided type `variable`.
+    ///
+    /// It is valid for a judgement to occur multiple times.
+    pub fn add_expression(&mut self, variable: &TypeVariable, expression: TypeExpression) {
+        // This is safe to unwrap as the only source of new type variables is the `add`
+        // method above, and so we know it will exist.
+        self.type_expressions.get_mut(variable).unwrap().push(expression);
+    }
+
+    /// Gets the typing expressions associated with the provided type
+    /// `variable`.
+    pub fn expressions(&self, variable: &TypeVariable) -> &TypeExprVec {
+        // This is safe to unwrap as the only source of new type variables is the `add`
+        // method above, and so we know it will exist.
+        self.type_expressions.get(variable).unwrap()
+    }
+
+    /// Gets the typing judgements associated with the provided type `variable`.
+    pub fn expressions_mut(&mut self, variable: &TypeVariable) -> &mut TypeExprVec {
+        // This is safe to unwrap as the only source of new type variables is the `add`
+        // method above, and so we know it will exist.
+        self.type_expressions.get_mut(variable).unwrap()
+    }
+
+    /// Gets the type variable associated with a value, if it exists, returning
+    /// [`None`] otherwise.
+    pub fn var_for_value(&self, value: &BoxedVal) -> Option<TypeVariable> {
+        self.expressions_and_vars.get_by_left(value).cloned()
+    }
+
+    /// Gets the value associated with a type variable, if it exists, returning
+    /// [`None`] otherwise.
+    pub fn value_for_var(&self, variable: &TypeVariable) -> Option<&BoxedVal> {
+        self.expressions_and_vars.get_by_right(variable)
+    }
+
+    /// Gets all of the values that are registered with the unifier state.
+    pub fn values(&self) -> Vec<&BoxedVal> {
+        self.expressions_and_vars.left_values().collect()
+    }
+
+    /// Gets all of the type variables that are registered with the unifier
+    /// state.
+    pub fn variables(&self) -> Vec<TypeVariable> {
+        self.expressions_and_vars.right_values().copied().collect()
+    }
+}
+
+impl Default for UnifierState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A type variable represents the possibly-unbound type of an expression.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct TypeVariable {
+    id: Uuid,
+}
+
+impl TypeVariable {
+    /// Creates a new, never-before-seen type variable.
+    ///
+    /// It is intended _only_ to be called from the [`UnifierState::add`] as
+    /// there should be no other way to construct a fresh type variable.
+    fn fresh() -> Self {
+        let id = Uuid::new_v4();
+        Self { id }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TypeExpression,
+            state::{TypeVariable, UnifierState},
+        },
+        vm::value::{Provenance, SymbolicValue},
+    };
+
+    #[test]
+    fn can_create_fresh_type_variable() {
+        TypeVariable::fresh();
+    }
+
+    #[test]
+    fn can_add_expression_for_type_variable() {
+        let mut state = UnifierState::new();
+        let value = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let type_variable = state.add(value);
+
+        let expression = TypeExpression::default_word();
+        state.add_expression(&type_variable, expression.clone());
+
+        assert_eq!(state.expressions(&type_variable), &vec![expression.clone()]);
+        assert_eq!(state.expressions_mut(&type_variable), &vec![expression]);
+    }
+
+    #[test]
+    fn can_get_type_variable_for_value() {
+        let mut state = UnifierState::new();
+        let value = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let type_variable = state.add(value.clone());
+
+        assert_eq!(state.var_for_value(&value), Some(type_variable));
+    }
+
+    #[test]
+    fn can_get_value_for_type_variable() {
+        let mut state = UnifierState::new();
+        let value = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let variable_ty_var = state.add(value.clone());
+
+        assert_eq!(state.value_for_var(&variable_ty_var), Some(&value));
+    }
+
+    #[test]
+    fn can_get_all_values_and_variables() {
+        let mut state = UnifierState::new();
+        let value_1 = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let value_2 = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let type_variable_1 = state.add(value_1.clone());
+        let type_variable_2 = state.add(value_2.clone());
+
+        let values = state.values();
+        assert!(values.contains(&&value_1));
+        assert!(values.contains(&&value_2));
+
+        let variables = state.variables();
+        assert!(variables.contains(&type_variable_1));
+        assert!(variables.contains(&type_variable_2));
+    }
+}

--- a/src/unifier/sugar/mapping_access.rs
+++ b/src/unifier/sugar/mapping_access.rs
@@ -1,0 +1,116 @@
+//! This module provides a re-sugaring pass that recognises accesses to
+//! individual storing slots as part of a mapping.
+
+use crate::{
+    unifier::{state::UnifierState, sugar::ReSugar},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This pass detects and folds expressions that access mappings in storage.
+///
+/// These have a form as follows:
+///
+/// ```code
+/// sha3(concat(key, slot_ix))
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct MappingAccess;
+
+impl MappingAccess {
+    /// Constructs a new instance of the mapping access re-sugaring pass.
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl ReSugar for MappingAccess {
+    fn run(
+        &mut self,
+        value: BoxedVal,
+        _state: &mut UnifierState,
+    ) -> crate::error::unification::Result<BoxedVal> {
+        fn insert_mapping_accesses(data: &SVD) -> Option<SVD> {
+            let SVD::Sha3 {data} = data else { return None };
+            let SVD::Concat {values} = &data.data else { return None };
+            let [key, slot] = &values[..] else { return None };
+
+            Some(SVD::MappingAddress {
+                key:  key.clone(),
+                slot: slot.clone(),
+            })
+        }
+
+        Ok(value.transform_data(insert_mapping_accesses))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            state::UnifierState,
+            sugar::{mapping_access::MappingAccess, ReSugar},
+        },
+        vm::value::{known::KnownWord, Provenance, SymbolicValue, SVD},
+    };
+
+    #[test]
+    fn resolves_mapping_accesses_at_top_level() -> anyhow::Result<()> {
+        let input_key = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let input_slot =
+            SymbolicValue::new_known_value(1, KnownWord::from(10), Provenance::Synthetic);
+        let concat = SymbolicValue::new(
+            2,
+            SVD::Concat {
+                values: vec![input_key.clone(), input_slot.clone()],
+            },
+            Provenance::Synthetic,
+        );
+        let hash = SymbolicValue::new(3, SVD::Sha3 { data: concat }, Provenance::Synthetic);
+
+        let mut state = UnifierState::new();
+        let result = MappingAccess.run(hash, &mut state)?;
+
+        match result.data {
+            SVD::MappingAddress { key, slot } => {
+                assert_eq!(key, input_key);
+                assert_eq!(slot, input_slot);
+            }
+            _ => panic!("Invalid payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_mapping_accesses_while_nested() -> anyhow::Result<()> {
+        let input_key = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let input_slot =
+            SymbolicValue::new_known_value(1, KnownWord::from(10), Provenance::Synthetic);
+        let concat = SymbolicValue::new(
+            2,
+            SVD::Concat {
+                values: vec![input_key.clone(), input_slot.clone()],
+            },
+            Provenance::Synthetic,
+        );
+        let hash = SymbolicValue::new(3, SVD::Sha3 { data: concat }, Provenance::Synthetic);
+        let not = SymbolicValue::new(4, SVD::Not { value: hash }, Provenance::Synthetic);
+
+        let mut state = UnifierState::new();
+        let result = MappingAccess.run(not, &mut state)?;
+
+        match result.data {
+            SVD::Not { value: bool } => match bool.data {
+                SVD::MappingAddress { key, slot } => {
+                    assert_eq!(key, input_key);
+                    assert_eq!(slot, input_slot);
+                }
+                _ => panic!("Invalid payload"),
+            },
+            _ => panic!("Invalid payload"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/unifier/sugar/mask_word.rs
+++ b/src/unifier/sugar/mask_word.rs
@@ -1,0 +1,215 @@
+//! This re-sugaring pass looks for operations that mask values to a
+//! well-defined length or sub-values, as these can be used to infer the width
+//! of a value.
+
+use crate::{
+    unifier::{state::UnifierState, sugar::ReSugar},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This pass detects and folds expressions that mask word-size values.
+///
+/// These have a form as follows:
+///
+/// ```code
+/// value & ((1 << shift) - 1)
+/// ```
+///
+/// where:
+/// - The operands to `&` may be flipped as the operator is symmetric.
+/// - The `((1 << shift) - 1)` mask may be constant-folded.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct MaskWord;
+
+impl MaskWord {
+    /// Constructs a new instance of the word mask re-sugaring pass.
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl ReSugar for MaskWord {
+    fn run(
+        &mut self,
+        value: BoxedVal,
+        _state: &mut UnifierState,
+    ) -> crate::error::unification::Result<BoxedVal> {
+        fn mask_arg(data: &SVD) -> Option<usize> {
+            // If there is a known data as the operand, and it hasn't been constant folded,
+            // we know that the mask itself _has_ been, so we just return it.
+            if let SVD::KnownData { value } = data {
+                return Some(usize::from(value));
+            }
+
+            let SVD::Subtract { left, right } = data else { return None };
+            let SVD::LeftShift { shift, value } = &left.data else { return None };
+            let SVD::KnownData { value: subtracted_value } = &right.data else { return None };
+            let SVD::KnownData { value: shift_amount } = &shift.data else { return None };
+            let SVD::KnownData { value: shifted_value } = &value.data else { return None };
+
+            if usize::from(subtracted_value) == 1 && usize::from(shifted_value) == 1 {
+                Some(usize::from(shift_amount))
+            } else {
+                None
+            }
+        }
+
+        fn insert_masks(data: &SVD) -> Option<SVD> {
+            let SVD::And { left, right } = data else { return None };
+
+            if let Some(mask_size) = mask_arg(&left.data) {
+                Some(SVD::WordMask {
+                    value: right.clone(),
+                    mask:  mask_size,
+                })
+            } else {
+                mask_arg(&right.data).map(|mask_size| SVD::WordMask {
+                    value: left.clone(),
+                    mask:  mask_size,
+                })
+            }
+        }
+
+        Ok(value.transform_data(insert_masks))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            state::UnifierState,
+            sugar::{mask_word::MaskWord, ReSugar},
+        },
+        vm::value::{known::KnownWord, Provenance, SymbolicValue, SymbolicValueData, SVD},
+    };
+
+    #[test]
+    fn resolves_word_masks_at_top_level() -> anyhow::Result<()> {
+        let one = SymbolicValue::new_known_value(0, KnownWord::from(1), Provenance::Synthetic);
+        let shift_amount =
+            SymbolicValue::new_known_value(1, KnownWord::from(12), Provenance::Synthetic);
+        let shift = SymbolicValue::new(
+            2,
+            SymbolicValueData::LeftShift {
+                value: one.clone(),
+                shift: shift_amount,
+            },
+            Provenance::Synthetic,
+        );
+        let subtract = SymbolicValue::new(
+            3,
+            SymbolicValueData::Subtract {
+                left:  shift,
+                right: one,
+            },
+            Provenance::Synthetic,
+        );
+        let input_value = SymbolicValue::new_value(4, Provenance::Synthetic);
+        let and = SymbolicValue::new(
+            4,
+            SymbolicValueData::And {
+                left:  input_value.clone(),
+                right: subtract,
+            },
+            Provenance::Synthetic,
+        );
+
+        let mut state = UnifierState::new();
+        let result = MaskWord.run(and, &mut state)?;
+
+        match &result.data {
+            SVD::WordMask { value, mask } => {
+                assert_eq!(value, &input_value);
+                assert_eq!(*mask, 12usize);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_word_masks_when_nested() -> anyhow::Result<()> {
+        let one = SymbolicValue::new_known_value(0, KnownWord::from(1), Provenance::Synthetic);
+        let shift_amount =
+            SymbolicValue::new_known_value(1, KnownWord::from(12), Provenance::Synthetic);
+        let shift = SymbolicValue::new(
+            2,
+            SymbolicValueData::LeftShift {
+                value: one.clone(),
+                shift: shift_amount,
+            },
+            Provenance::Synthetic,
+        );
+        let subtract = SymbolicValue::new(
+            3,
+            SymbolicValueData::Subtract {
+                left:  shift,
+                right: one,
+            },
+            Provenance::Synthetic,
+        );
+        let input_value = SymbolicValue::new_value(4, Provenance::Synthetic);
+        let and = SymbolicValue::new(
+            4,
+            SymbolicValueData::And {
+                left:  input_value.clone(),
+                right: subtract,
+            },
+            Provenance::Synthetic,
+        );
+        let not = SymbolicValue::new(
+            4,
+            SymbolicValueData::Not { value: and },
+            Provenance::Synthetic,
+        );
+
+        let mut state = UnifierState::new();
+        let result = MaskWord.run(not, &mut state)?;
+
+        match &result.data {
+            SVD::Not { value } => match &value.data {
+                SVD::WordMask { value, mask } => {
+                    assert_eq!(value, &input_value);
+                    assert_eq!(*mask, 12usize);
+                }
+                _ => panic!("Incorrect payload"),
+            },
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_word_masks_with_constant_masks() -> anyhow::Result<()> {
+        let input_value = SymbolicValue::new_value(4, Provenance::Synthetic);
+        let input_mask = SymbolicValue::new_known_value(
+            0,
+            KnownWord::from(0x0000ffff0000),
+            Provenance::Synthetic,
+        );
+        let and = SymbolicValue::new(
+            4,
+            SymbolicValueData::And {
+                left:  input_mask,
+                right: input_value.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        let mut state = UnifierState::new();
+        let result = MaskWord.run(and, &mut state)?;
+
+        match &result.data {
+            SVD::WordMask { value, mask } => {
+                assert_eq!(value, &input_value);
+                assert_eq!(*mask, 0x0000ffff0000);
+            }
+            _ => panic!("Incorrect payload"),
+        };
+
+        Ok(())
+    }
+}

--- a/src/unifier/sugar/mod.rs
+++ b/src/unifier/sugar/mod.rs
@@ -1,0 +1,108 @@
+//! This module contains the definition of the `ReSugar` trait that provides the
+//! unifier with the ability to add higher-level value constructors based on
+//! lower-level patterns.
+
+pub mod mapping_access;
+pub mod mask_word;
+
+use std::{
+    any::{Any, TypeId},
+    fmt::Debug,
+};
+
+use downcast_rs::Downcast;
+
+use crate::{
+    error::unification::Result,
+    unifier::{
+        state::UnifierState,
+        sugar::{mapping_access::MappingAccess, mask_word::MaskWord},
+    },
+    vm::value::BoxedVal,
+};
+
+/// A trait representing processes for _introducing_ higher-level constructs
+/// into the symbolic value representation.
+pub trait ReSugar
+where
+    Self: Any + Debug + Downcast,
+{
+    /// Executes the pass on the provided `value`, with access to the pass state
+    /// in `self` and the unifier state in `state`, returning a
+    /// potentially-transformed `value`.
+    ///
+    /// Implementations of `run` can assume that the input `value` has had
+    /// [`crate::vm::value::SymbolicValueData::constant_fold`] called on it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if something goes wrong with the re-sugaring process.
+    fn run(&mut self, value: BoxedVal, state: &mut UnifierState) -> Result<BoxedVal>;
+}
+
+/// A container for an ordered set of re-sugaring passes that will be run in
+/// order.
+#[derive(Debug)]
+pub struct ReSugarPasses {
+    /// The ordered list of passes that will be executed in order.
+    passes: Vec<Box<dyn ReSugar>>,
+}
+
+impl ReSugarPasses {
+    /// Adds the `pass` to the end of the pass ordering.
+    ///
+    /// If a pass of the given type already exists in the ordering, it will not
+    /// be added.
+    pub fn add<P: ReSugar>(&mut self, pass: P) {
+        let ids: Vec<TypeId> = self.passes.iter().map(|p| p.as_ref().type_id()).collect();
+        let pass_id = pass.type_id();
+
+        if ids.contains(&pass_id) {
+            return;
+        }
+
+        let alloc = Box::new(pass);
+        self.passes.push(alloc);
+    }
+
+    /// Gets a reference to the pass of the given type, if it exists in the
+    /// passes container.
+    pub fn get<P: ReSugar>(&self) -> Option<&P> {
+        self.passes
+            .iter()
+            .find(|p| p.as_ref().as_any().is::<P>())
+            .and_then(|p| p.as_ref().as_any().downcast_ref::<P>())
+    }
+
+    /// Gets a reference to the pass of the given type, if it exists in the
+    /// passes container.
+    pub fn get_mut<P: ReSugar>(&mut self) -> Option<&mut P> {
+        self.passes
+            .iter_mut()
+            .find(|p| p.as_ref().as_any().is::<P>())
+            .and_then(|p| p.as_mut().as_any_mut().downcast_mut::<P>())
+    }
+
+    /// Runs all of the contained passes in order on the provided `value`, with
+    /// access to modify the unifier `state`, returning the potentially-modified
+    /// value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if any of the passes error.
+    pub fn run(&mut self, mut value: BoxedVal, state: &mut UnifierState) -> Result<BoxedVal> {
+        for pass in self.passes.iter_mut() {
+            value = pass.run(value, state)?;
+        }
+
+        Ok(value)
+    }
+}
+
+impl Default for ReSugarPasses {
+    fn default() -> Self {
+        Self {
+            passes: vec![MaskWord::new(), MappingAccess::new()],
+        }
+    }
+}

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -19,6 +19,7 @@ use crate::{
         instructions::{ExecutionThread, InstructionStream},
         state::{stack::LocatedStackHandle, VMState},
         thread::VMThread,
+        value::BoxedVal,
     },
 };
 
@@ -345,6 +346,16 @@ pub struct ExecutionResult {
     /// full coverage of the bytecode. It is recommended to inspect the errors
     /// themselves before continuing to determine if the data is useful.
     pub errors: Errors,
+}
+
+impl ExecutionResult {
+    /// Gathers all of the symbolic values known about by the execution result.
+    pub fn all_values(&self) -> Vec<BoxedVal> {
+        let mut values = Vec::new();
+        self.states.iter().for_each(|state| values.extend(state.all_values()));
+
+        values
+    }
 }
 
 /// The configuration for the virtual machine instance.

--- a/src/vm/state/memory.rs
+++ b/src/vm/state/memory.rs
@@ -2,7 +2,10 @@
 
 use std::{collections::HashMap, hash::Hash};
 
-use crate::vm::value::{known::KnownWord, BoxedVal, Provenance, SymbolicValue, SymbolicValueData};
+use crate::{
+    constant::WORD_SIZE,
+    vm::value::{known::KnownWord, BoxedVal, Provenance, SymbolicValue, SymbolicValueData},
+};
 
 /// A representation of the transient memory of the symbolic virtual machine.
 ///
@@ -42,8 +45,8 @@ impl Memory {
         }
     }
 
-    /// Stores the provided `value` (of size 256-bits) at the provided `offset`
-    /// in the memory.
+    /// Stores the provided `value` (of size [`WORD_SIZE`]) at the provided
+    /// `offset` in the memory.
     ///
     /// This will overwrite any existing value at the provided `offset`.
     ///
@@ -244,6 +247,21 @@ impl Memory {
     pub fn offsets(&self) -> Vec<&BoxedVal> {
         self.symbolic_offsets.keys().collect()
     }
+
+    /// Gets all of the values that are registered in the virtual machine memory
+    /// at the time of calling.
+    pub fn all_values(&self) -> Vec<BoxedVal> {
+        let mut values = Vec::new();
+        self.constant_offsets
+            .values()
+            .for_each(|more| values.extend(more.iter().map(|s| s.data.clone())));
+        values.extend(self.symbolic_offsets.keys().cloned());
+        self.symbolic_offsets
+            .values()
+            .for_each(|more| values.extend(more.iter().map(|s| s.data.clone())));
+
+        values
+    }
 }
 
 impl Default for Memory {
@@ -272,7 +290,7 @@ impl MemStoreSize {
     pub fn bits_count(&self) -> usize {
         match self {
             MemStoreSize::Byte => 8,
-            MemStoreSize::Word => 256,
+            MemStoreSize::Word => WORD_SIZE,
         }
     }
 }

--- a/src/vm/state/mod.rs
+++ b/src/vm/state/mod.rs
@@ -162,6 +162,19 @@ impl VMState {
 
         fork
     }
+
+    /// Gets all of the values that are registered in the virtual machine state
+    /// at the time of calling.
+    pub fn all_values(&self) -> Vec<BoxedVal> {
+        let mut values = Vec::new();
+        values.extend(self.stack.all_values());
+        values.extend(self.memory.all_values());
+        values.extend(self.storage.all_values());
+        values.extend(self.recorded_values.iter().cloned());
+        values.extend(self.logged_values.iter().cloned());
+
+        values
+    }
 }
 
 #[cfg(test)]

--- a/src/vm/state/stack.rs
+++ b/src/vm/state/stack.rs
@@ -20,9 +20,9 @@ use crate::{
 /// # Depth
 ///
 /// In a true EVM, it is a depth [`MAXIMUM_STACK_DEPTH`] stack, where each item
-/// is word (256-bit) sized. Here, the symbolic virtual machine maintains the
-/// same maximum depth, but instead stores [`crate::vm::value::SymbolicValue`]s
-/// instead of words.
+/// is of size [`crate::constant::WORD_SIZE`]. Here, the symbolic virtual
+/// machine maintains the same maximum depth, but instead stores
+/// [`crate::vm::value::SymbolicValue`]s instead of words.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Stack {
     data: Vec<BoxedVal>,
@@ -161,6 +161,12 @@ impl Stack {
             instruction_pointer,
             stack: self,
         }
+    }
+
+    /// Gets all of the values that are registered in the virtual machine stack
+    /// at the time of calling.
+    pub fn all_values(&self) -> Vec<BoxedVal> {
+        self.data.to_vec()
     }
 }
 

--- a/src/vm/state/storage.rs
+++ b/src/vm/state/storage.rs
@@ -118,6 +118,22 @@ impl Storage {
 
         known_keys
     }
+
+    /// Gets all of the values that are registered in the virtual machine stack
+    /// at the time of calling.
+    pub fn all_values(&self) -> Vec<BoxedVal> {
+        let mut values = Vec::new();
+        values.extend(self.known_slots.keys().cloned());
+        self.known_slots
+            .values()
+            .for_each(|more| values.extend(more.iter().cloned()));
+        values.extend(self.symbolic_slots.keys().cloned());
+        self.symbolic_slots
+            .values()
+            .for_each(|more| values.extend(more.iter().cloned()));
+
+        values
+    }
 }
 
 impl Default for Storage {

--- a/src/vm/value/known.rs
+++ b/src/vm/value/known.rs
@@ -9,7 +9,7 @@ use ethnum::U256;
 /// here there is no interaction with a real EVM.
 ///
 /// For more information on the concrete definition of these data types, please
-/// see [`crate::unifier::types::AbiType`].
+/// see [`crate::unifier::abi::AbiType`].
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct KnownWord {
     value: U256,
@@ -80,24 +80,28 @@ impl From<&KnownWord> for usize {
     }
 }
 
+/// Obtains a [`bool`] from a known word.
 impl From<KnownWord> for bool {
     fn from(value: KnownWord) -> Self {
         value.value != U256::from(0u8)
     }
 }
 
+/// Obtains a [`bool`] from a known word.
 impl From<&KnownWord> for bool {
     fn from(value: &KnownWord) -> Self {
         value.value != U256::from(0u8)
     }
 }
 
+/// Obtains a known word from a [`bool`].
 impl From<bool> for KnownWord {
     fn from(value: bool) -> Self {
         if value { Self::from(1) } else { Self::from(0) }
     }
 }
 
+/// Pretty-prints the known word as a hexadecimal-encoded number.
 impl Display for KnownWord {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let str = hex::encode(self.value.to_be_bytes());


### PR DESCRIPTION
# Summary

The unifier operates as follows:

1. All values in the program are run through a re-sugaring process that discovers higher-level constructs and inserts them into the value trees.
2. The unifier then generates a type variable for each expression.
3. Heuristics are run on each value in order to provide typing evidence in the form of Type Expressions for the type of each value. These expressions are associated with the type variables.
4. The unifier performs unification on the type variables to discover types.

# Details

This is primarily a skeleton, and only implements a portion of 1 and the supporting structures for the rest.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
