### PR TITLE
Implement value gathering

### DIFF
--- a/src/analyzer/state.rs
+++ b/src/analyzer/state.rs
@@ -54,6 +54,7 @@ impl State for UnifierReady {}
 /// ready to provide the concrete storage layout.
 #[derive(Debug)]
 pub struct UnificationComplete {
-    pub layout: StorageLayout,
+    pub unifier: Unifier,
+    pub layout:  StorageLayout,
 }
 impl State for UnificationComplete {}

--- a/src/opcode/macros.rs
+++ b/src/opcode/macros.rs
@@ -28,6 +28,7 @@
 #[macro_export]
 macro_rules! bytecode {
     ($($path:expr),*$(,)?) => {{
+        use $crate::opcode::Opcode;
         let mut vec: Vec<u8> = vec![];
         $(vec.extend($path.encode()));*;
         vec

--- a/src/unifier/mod.rs
+++ b/src/unifier/mod.rs
@@ -1,9 +1,15 @@
 //! This module contains the [`Unifier`] and related utilities.
 
+use std::collections::VecDeque;
+
 use crate::{
     error::unification::{Errors, Result},
-    unifier::{state::UnifierState, sugar::ReSugarPasses},
+    unifier::{
+        state::{TypeVariable, UnifierState},
+        sugar::ReSugarPasses,
+    },
     vm::{value::BoxedVal, ExecutionResult},
+    StorageLayout,
 };
 
 pub mod abi;
@@ -44,12 +50,30 @@ impl Unifier {
         }
     }
 
+    /// Executes the unifier on the data with which it was constructed,
+    /// returning a storage layout where possible.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the unifier's execution fails for any reason.
+    pub fn run(&mut self) -> Result<StorageLayout> {
+        let sugared_values = self.re_sugar()?;
+        self.assign_vars(sugared_values);
+        self.analyze()?;
+        self.unify()
+    }
+
     /// Executes the re-sugaring passes on all of the available symbolic values,
     /// potentially transforming them, and then returns the associated type
     /// variables for each expression.
     ///
     /// Executing this method inserts all of the transformed values into the
     /// state of the unifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if one or more of the re-sugaring passes returns an
+    /// error.
     pub fn re_sugar(&mut self) -> Result<Vec<BoxedVal>> {
         let mut new_values = Vec::new();
         let mut errors = Errors::new();
@@ -67,10 +91,57 @@ impl Unifier {
         }
     }
 
-    // TODO [Ara] Discover storage slots in re-sugaring
-    // TODO [Ara] Assign type variables
-    // TODO [Ara] Run heuristics
-    // TODO [Ara] Unify
+    /// Assigns type variables to all of the provided `values` and their
+    /// sub-values, registering them in the unifier state and returning the
+    /// sub-values associated with their type variables.
+    ///
+    /// This function must be run after any operations (such as
+    /// [`Self::re_sugar`]) that mutate the values.
+    pub fn assign_vars(&mut self, values: Vec<BoxedVal>) -> Vec<(&BoxedVal, TypeVariable)> {
+        // Create a queue of values that have not yet been processed.
+        let mut queue = VecDeque::new();
+        queue.extend(values);
+
+        // While the queue still has entries, we get the children of the entry, add
+        // them, and register the entry.
+        while let Some(v) = queue.pop_front() {
+            let inline: Vec<BoxedVal> = v.children().into_iter().cloned().collect();
+            queue.extend(inline);
+            self.state.add(v);
+        }
+
+        // Get the expected data.
+        self.state.pairs()
+    }
+
+    /// Runs the unifier's configured heuristics on all of the values that have
+    /// been registered with the unifier.
+    ///
+    /// Analysis will produce no results if [`Self::assign_vars`] has not yet
+    /// been run. It will also produce degraded results if [`Self::re_sugar`]
+    /// has not been run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if one or more of the heuristics returns an error.
+    pub fn analyze(&mut self) -> Result<()> {
+        todo!("Needs assign_vars to be done first")
+    }
+
+    /// Runs unification on all of the type variables registered in the unifier
+    /// to discover the most concrete types for the storage slots in the
+    /// contract.
+    ///
+    /// Analysis will produce no results if [`Self::assign_vars`] has not yet
+    /// been run. It will also produce degraded results if [`Self::analyze`]
+    /// has not been run.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Err`] if the unification process fails.
+    pub fn unify(&mut self) -> Result<StorageLayout> {
+        todo!("Needs analyze to be done first")
+    }
 
     /// Gets the unifier's configuration to allow inspection.
     pub fn config(&self) -> &Config {
@@ -118,4 +189,68 @@ impl Default for Config {
 }
 
 #[cfg(test)]
-mod test {}
+mod test {
+    use crate::{
+        bytecode,
+        error::execution,
+        opcode::control::Invalid,
+        unifier::{Config, Unifier},
+        vm::{
+            instructions::InstructionStream,
+            value::{known::KnownWord, Provenance, SymbolicValue, SVD},
+            ExecutionResult,
+        },
+    };
+
+    #[test]
+    fn assigns_type_variables_to_all_sub_expressions() {
+        let var_1 = SymbolicValue::new_value(0, Provenance::Synthetic);
+        let var_2 = SymbolicValue::new_value(1, Provenance::Synthetic);
+        let add = SymbolicValue::new(
+            2,
+            SVD::Add {
+                left:  var_1.clone(),
+                right: var_2.clone(),
+            },
+            Provenance::Synthetic,
+        );
+        let storage_slot = SymbolicValue::new(
+            3,
+            SVD::StorageSlot {
+                index: KnownWord::from(10),
+            },
+            Provenance::Synthetic,
+        );
+        let mapping = SymbolicValue::new(
+            4,
+            SVD::MappingAddress {
+                slot: storage_slot.clone(),
+                key:  add.clone(),
+            },
+            Provenance::Synthetic,
+        );
+        let var_3 = SymbolicValue::new_value(5, Provenance::Synthetic);
+
+        let values = vec![mapping.clone(), var_3.clone()];
+
+        let config = Config::default();
+        let mut unifier = Unifier::new(
+            config,
+            ExecutionResult {
+                instructions: InstructionStream::try_from(bytecode![Invalid].as_slice()).unwrap(),
+                states:       Vec::new(),
+                errors:       execution::Errors::new(),
+            },
+        );
+
+        unifier.assign_vars(values);
+        let state = unifier.state();
+
+        assert!(state.var_for_value(&var_1).is_some());
+        assert!(state.var_for_value(&var_2).is_some());
+        assert!(state.var_for_value(&add).is_some());
+        assert!(state.var_for_value(&storage_slot).is_some());
+        assert!(state.var_for_value(&mapping).is_some());
+        assert!(state.var_for_value(&var_3).is_some());
+    }
+}

--- a/src/unifier/state.rs
+++ b/src/unifier/state.rs
@@ -102,6 +102,11 @@ impl UnifierState {
     pub fn variables(&self) -> Vec<TypeVariable> {
         self.expressions_and_vars.right_values().copied().collect()
     }
+
+    /// Gets the pairs of `(value, type_var)` from the state of the unifier.
+    pub fn pairs(&self) -> Vec<(&BoxedVal, TypeVariable)> {
+        self.expressions_and_vars.iter().map(|(v, t)| (v, *t)).collect()
+    }
 }
 
 impl Default for UnifierState {

--- a/src/unifier/sugar/mapping_access.rs
+++ b/src/unifier/sugar/mapping_access.rs
@@ -1,5 +1,5 @@
 //! This module provides a re-sugaring pass that recognises accesses to
-//! individual storing slots as part of a mapping.
+//! individual storage slots as part of a mapping.
 
 use crate::{
     unifier::{state::UnifierState, sugar::ReSugar},

--- a/src/unifier/sugar/mod.rs
+++ b/src/unifier/sugar/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod mapping_access;
 pub mod mask_word;
+pub mod storage_slots;
 
 use std::{
     any::{Any, TypeId},
@@ -16,7 +17,7 @@ use crate::{
     error::unification::Result,
     unifier::{
         state::UnifierState,
-        sugar::{mapping_access::MappingAccess, mask_word::MaskWord},
+        sugar::{mapping_access::MappingAccess, mask_word::MaskWord, storage_slots::StorageSlots},
     },
     vm::value::BoxedVal,
 };
@@ -102,7 +103,7 @@ impl ReSugarPasses {
 impl Default for ReSugarPasses {
     fn default() -> Self {
         Self {
-            passes: vec![MaskWord::new(), MappingAccess::new()],
+            passes: vec![MaskWord::new(), MappingAccess::new(), StorageSlots::new()],
         }
     }
 }

--- a/src/unifier/sugar/storage_slots.rs
+++ b/src/unifier/sugar/storage_slots.rs
@@ -1,0 +1,143 @@
+//! This module provides a re-sugaring pass that recognises accesses to storage
+//! slots, and wraps the constant slots in fixed expressions.
+
+use crate::{
+    unifier::{state::UnifierState, sugar::ReSugar},
+    vm::value::{BoxedVal, SymbolicValue, SVD},
+};
+
+/// This pass detects and wraps expressions that access constant storage slots
+/// so that these constants can be distinguished from other constants of the
+/// same value.
+///
+/// This pass relies on the results of the [`super::mapping_access`] pass, and
+/// hence must be ordered after it in the re-sugar pass ordering.
+///
+/// # Note
+///
+/// It currently only recognises one case (mappings), but will be extended in
+/// the future alongside other re-sugaring passes.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct StorageSlots;
+
+impl StorageSlots {
+    /// Constructs a new instance of the storage slot access re-sugaring pass.
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl ReSugar for StorageSlots {
+    fn run(
+        &mut self,
+        value: BoxedVal,
+        _state: &mut UnifierState,
+    ) -> crate::error::unification::Result<BoxedVal> {
+        fn insert_storage_accesses(data: &SVD) -> Option<SVD> {
+            match data {
+                SVD::MappingAddress { key, slot } => {
+                    let SVD::KnownData { value } = &slot.data else { return None };
+                    let slot = SymbolicValue::new(
+                        slot.instruction_pointer,
+                        SVD::StorageSlot { index: *value },
+                        slot.provenance,
+                    );
+                    Some(SVD::MappingAddress {
+                        key: key.clone(),
+                        slot,
+                    })
+                }
+                _ => None,
+            }
+        }
+
+        Ok(value.transform_data(insert_storage_accesses))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            state::UnifierState,
+            sugar::{storage_slots::StorageSlots, ReSugar},
+        },
+        vm::value::{known::KnownWord, Provenance, SymbolicValue, SVD},
+    };
+
+    #[test]
+    fn lifts_storage_slots_in_mappings_at_top_level() -> anyhow::Result<()> {
+        let slot_index_constant =
+            SymbolicValue::new_known_value(0, KnownWord::from(7), Provenance::Synthetic);
+        let mapping_key = SymbolicValue::new_value(1, Provenance::Synthetic);
+        let mapping_access = SymbolicValue::new(
+            2,
+            SVD::MappingAddress {
+                key:  mapping_key.clone(),
+                slot: slot_index_constant,
+            },
+            Provenance::Synthetic,
+        );
+
+        let mut state = UnifierState::new();
+        let result = StorageSlots.run(mapping_access, &mut state)?;
+
+        match result.data {
+            SVD::MappingAddress { key, slot } => {
+                assert_eq!(key, mapping_key);
+                match slot.data {
+                    SVD::StorageSlot { index } => {
+                        assert_eq!(index, KnownWord::from(7))
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn lifts_storage_slots_in_mappings_when_nested() -> anyhow::Result<()> {
+        let slot_index_constant =
+            SymbolicValue::new_known_value(0, KnownWord::from(7), Provenance::Synthetic);
+        let mapping_key = SymbolicValue::new_value(1, Provenance::Synthetic);
+        let mapping_access = SymbolicValue::new(
+            2,
+            SVD::MappingAddress {
+                key:  mapping_key.clone(),
+                slot: slot_index_constant,
+            },
+            Provenance::Synthetic,
+        );
+        let not = SymbolicValue::new(
+            3,
+            SVD::Not {
+                value: mapping_access,
+            },
+            Provenance::Synthetic,
+        );
+
+        let mut state = UnifierState::new();
+        let result = StorageSlots.run(not, &mut state)?;
+
+        match result.data {
+            SVD::Not { value } => match value.data {
+                SVD::MappingAddress { key, slot } => {
+                    assert_eq!(key, mapping_key);
+                    match slot.data {
+                        SVD::StorageSlot { index } => {
+                            assert_eq!(index, KnownWord::from(7))
+                        }
+                        _ => panic!("Incorrect payload"),
+                    }
+                }
+                _ => panic!("Incorrect payload"),
+            },
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -385,7 +385,6 @@ mod test {
             control::{Invalid, JumpDest, JumpI, Return},
             logic::IsZero,
             memory::{CallDataSize, MStore, PushN, SStore},
-            Opcode,
         },
         vm::{instructions::InstructionStream, Config, VM},
     };


### PR DESCRIPTION
# Summary

The unifier is now capable of assigning type variables to _all_ values that are known about in the unifier after running the re-sugaring passes.

It also now recognises some usage of concrete storage slots and makes these concrete at the execution tree level.

# Details

Please check for missed children in `SVD::children()`.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
