### PR TITLE
Implement the inference rule for dynamic arrays

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -42,3 +42,6 @@ pub const MAXIMUM_STACK_DEPTH: usize = 1024;
 
 /// The width of word on the EVM in bits.
 pub const WORD_SIZE: usize = 256;
+
+/// The default number of times that the virtual machine will visit each opcode.
+pub const DEFAULT_ITERATIONS_PER_OPCODE: usize = 10;

--- a/src/opcode/memory.rs
+++ b/src/opcode/memory.rs
@@ -55,7 +55,7 @@ impl Opcode for CallDataLoad {
         // Then we construct the returned value
         let value = SymbolicValue::new_from_execution(
             instruction_pointer,
-            SymbolicValueData::CallData { offset, size },
+            SymbolicValueData::call_data(offset, size),
         );
 
         // And push it onto the stack
@@ -198,10 +198,7 @@ impl Opcode for CallDataCopy {
                     );
                     let value = SymbolicValue::new_from_execution(
                         instruction_pointer,
-                        SymbolicValueData::CallData {
-                            offset: src_offset,
-                            size:   num_32.clone(),
-                        },
+                        SymbolicValueData::call_data(src_offset, num_32.clone()),
                     );
                     memory.store(dest_offset, value);
                 }
@@ -209,7 +206,7 @@ impl Opcode for CallDataCopy {
             _ => {
                 let value = SymbolicValue::new_from_execution(
                     instruction_pointer,
-                    SymbolicValueData::CallData { offset, size },
+                    SymbolicValueData::call_data(offset, size),
                 );
                 memory.store(dest_offset, value);
             }
@@ -1485,7 +1482,7 @@ mod test {
         let memory = vm.state()?.memory_mut();
         let loaded = memory.load(&dest_offset);
         match &loaded.data {
-            SymbolicValueData::CallData { offset, size } => {
+            SymbolicValueData::CallData { offset, size, .. } => {
                 assert_eq!(offset, &input_offset);
                 assert_eq!(size, &input_size);
             }

--- a/src/unifier/abi.rs
+++ b/src/unifier/abi.rs
@@ -19,6 +19,10 @@ use ethnum::U256;
 /// now.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum AbiType {
+    /// An unknown type, useful for the container types where we know something
+    /// is a concrete container but not of what type(s).
+    Any,
+
     /// Unsigned integers of a given `size` in bits, where `8 < size <= 256 &&
     /// size % 8 == 0`.
     UInt { size: u16 },
@@ -31,13 +35,6 @@ pub enum AbiType {
     /// interpretation.
     Address,
 
-    /// Booleans, assumed equivalent to `UInt { size: 8 }` except for
-    /// interpretation.
-    Bool,
-
-    /// Byte arrays of a fixed `length`, where `0 < length <= 32`.
-    Bytes { length: u8 },
-
     /// A selector, assumed equivalent to `Bytes { length: 4 }` except for
     /// interpretation.
     Selector,
@@ -47,19 +44,22 @@ pub enum AbiType {
     /// 24 }`.
     Function,
 
+    /// Booleans, assumed equivalent to `UInt { size: 8 }` except for
+    /// interpretation.
+    Bool,
+
     /// A fixed-`size` array containing elements of an element type `tp`.
     Array { size: U256, tp: Box<AbiType> },
 
-    /// A dynamically-sized byte array, with each element packed.
-    DynBytes,
+    /// Byte arrays of a fixed `length`, where `0 < length <= 32`.
+    Bytes { length: u8 },
 
     /// A dynamically-sized array containing elements of a type `tp`.
     DynArray { tp: Box<AbiType> },
 
+    /// A dynamically-sized byte array, with each element packed.
+    DynBytes,
+
     /// A mapping from `key_tp` to `val_tp`.
     Mapping { key_tp: Box<AbiType>, val_tp: Box<AbiType> },
-
-    /// An unknown type, useful for the container types where we know something
-    /// is a concrete container but not of what type(s).
-    Any,
 }

--- a/src/unifier/inference_rule/dynamic_array_write.rs
+++ b/src/unifier/inference_rule/dynamic_array_write.rs
@@ -1,1 +1,138 @@
+//! This module contains the definition of an inference rule for typing dynamic
+//! array writes.
 
+use crate::{
+    unifier::{
+        expression::TE,
+        inference_rule::InferenceRule,
+        state::{TypeVariable, TypingState},
+    },
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the equations `d = dynamic_array<b>`, `f = unsigned`, `b =
+/// g` for expressions of the following form.
+///
+/// ```code
+/// s_store(storage_slot(dynamic_array<storage_slot(base_slot)>[index]), value)
+///    a          b            c             d          e         f        g
+/// ```
+///
+/// where
+/// - The second row are the type variable names for the corresponding
+///   expression above. These type variables extend over the whole enclosing
+///   expression.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DynamicArrayWriteRule;
+
+impl InferenceRule for DynamicArrayWriteRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        _a_tv: TypeVariable,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::StorageWrite { key: b, value: g } = &value.data else { return Ok(()) };
+        let SVD::StorageSlot { key: c } = &b.data else { return Ok(()) };
+        let SVD::DynamicArrayAccess { slot: d, index: f } = &c.data else { return Ok(()) };
+        let SVD::StorageSlot { .. } = &d.data else { return Ok(()) };
+
+        // `b = g`
+        let b_tv = state.var_unchecked(b);
+        let g_tv = state.var_unchecked(g);
+        state.infer(b_tv, TE::eq(g_tv));
+
+        // `f = unsigned`
+        let f_tv = state.var_unchecked(f);
+        state.infer(f_tv, TE::unsigned_word(None));
+
+        // `d = dynamic_array<b>`
+        let d_tv = state.var_unchecked(d);
+        state.infer(d_tv, TE::dyn_array(b_tv));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{dynamic_array_write::DynamicArrayWriteRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_inference_equations() -> anyhow::Result<()> {
+        // Create a value of the relevant structure
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let index = SV::new_value(1, Provenance::Synthetic);
+        let base_slot = SV::new_value(2, Provenance::Synthetic);
+        let slot_of_base_slot = SV::new(
+            3,
+            SVD::StorageSlot {
+                key: base_slot.clone(),
+            },
+            Provenance::Synthetic,
+        );
+        let dyn_array = SV::new(
+            4,
+            SVD::DynamicArrayAccess {
+                slot:  slot_of_base_slot.clone(),
+                index: index.clone(),
+            },
+            Provenance::Synthetic,
+        );
+        let slot_of_dyn_array = SV::new(
+            5,
+            SVD::StorageSlot {
+                key: dyn_array.clone(),
+            },
+            Provenance::Synthetic,
+        );
+        let store = SV::new(
+            6,
+            SVD::StorageWrite {
+                key:   slot_of_dyn_array.clone(),
+                value: value.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Set up the unifier state
+        let mut state = TypingState::empty();
+        let g_tv = state.register(value);
+        let f_tv = state.register(index);
+        let e_tv = state.register(base_slot);
+        let d_tv = state.register(slot_of_base_slot);
+        let c_tv = state.register(dyn_array);
+        let b_tv = state.register(slot_of_dyn_array);
+        let a_tv = state.register(store.clone());
+
+        // Run the inference rule
+        DynamicArrayWriteRule.infer(&store, a_tv, &mut state)?;
+
+        // Check that we end up with expected results in the state
+        assert!(state.inferences(g_tv).is_empty());
+
+        assert_eq!(state.inferences(f_tv).len(), 1);
+        assert!(state.inferences(f_tv).contains(&TE::unsigned_word(None)));
+
+        assert!(state.inferences(e_tv).is_empty());
+
+        assert_eq!(state.inferences(d_tv).len(), 1);
+        assert!(state.inferences(d_tv).contains(&TE::dyn_array(b_tv)));
+
+        assert!(state.inferences(c_tv).is_empty());
+
+        assert_eq!(state.inferences(b_tv).len(), 1);
+        assert!(state.inferences(b_tv).contains(&TE::eq(g_tv)));
+
+        assert!(state.inferences(a_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/mod.rs
+++ b/src/unifier/inference_rule/mod.rs
@@ -19,7 +19,11 @@ use downcast_rs::Downcast;
 use crate::{
     error::unification::Result,
     unifier::{
-        inference_rule::{mapping_write::MappingWriteRule, storage_write::StorageWriteRule},
+        inference_rule::{
+            dynamic_array_write::DynamicArrayWriteRule,
+            mapping_write::MappingWriteRule,
+            storage_write::StorageWriteRule,
+        },
         state::{TypeVariable, TypingState},
     },
     vm::value::BoxedVal,
@@ -108,6 +112,7 @@ impl Default for InferenceRules {
         let mut rules = Self::new();
         rules.add(StorageWriteRule);
         rules.add(MappingWriteRule);
+        rules.add(DynamicArrayWriteRule);
 
         rules
     }

--- a/src/unifier/lift/dynamic_array_access.rs
+++ b/src/unifier/lift/dynamic_array_access.rs
@@ -17,9 +17,12 @@ use crate::{
 ///
 /// where:
 /// - `slot` is the storage slot key.
-/// - The `sha3(slot)` expression may be constant-folded.
 /// - `index` is the index in the array to write to.
 /// - `value` is the value to be written to `index` in the array.
+///
+/// Note that this pass must be run _after_
+/// [`crate::unifier::lift::recognise_hashed_slots::StorageSlotHashes`] as it
+/// relies on its results.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DynamicArrayAccess;
 
@@ -37,22 +40,14 @@ impl Lift for DynamicArrayAccess {
     ) -> crate::error::unification::Result<BoxedVal> {
         fn lift_dyn_array_accesses(value: &SVD) -> Option<SVD> {
             let SVD::StorageWrite { key, value } = &value else { return None };
-            let SVD::Add {left, right} = &key.data else { return None };
-
-            // We have to deal with two cases, the raw hash, and the optimised hash
-            let slot = match &left.data {
-                SVD::StorageSlot { .. } => left.clone().transform_data(lift_dyn_array_accesses),
-                SVD::Sha3 { data } => match &data.data {
-                    SVD::KnownData { .. } => data.clone().transform_data(lift_dyn_array_accesses),
-                    _ => return None,
-                },
-                _ => return None,
-            };
+            let SVD::Add { left, right } = &key.data else { return None };
+            let SVD::Sha3 { data } = &left.data else { return None };
+            let SVD::KnownData { .. } = &data.data else { return None };
 
             let access = SV::new(
                 key.instruction_pointer,
                 SVD::DynamicArrayAccess {
-                    slot,
+                    slot:  data.clone().transform_data(lift_dyn_array_accesses),
                     index: right.clone().transform_data(lift_dyn_array_accesses),
                 },
                 key.provenance,
@@ -81,59 +76,7 @@ mod test {
     };
 
     #[test]
-    fn lifts_optimised_dyn_array_accesses() -> anyhow::Result<()> {
-        // Prepare the data
-        let input_value = SV::new_value(0, Provenance::Synthetic);
-        let input_index = SV::new_value(1, Provenance::Synthetic);
-        let hash = SV::new(
-            2,
-            SVD::StorageSlot {
-                key: SV::new_known_value(3, KnownWord::from(3), Provenance::Synthetic),
-            },
-            Provenance::Synthetic,
-        );
-        let add = SV::new(
-            3,
-            SVD::Add {
-                left:  hash.clone(),
-                right: input_index.clone(),
-            },
-            Provenance::Synthetic,
-        );
-        let store = SV::new(
-            4,
-            SVD::StorageWrite {
-                key:   add,
-                value: input_value.clone(),
-            },
-            Provenance::Synthetic,
-        );
-
-        // Run the pass
-        let state = TypingState::empty();
-        let result = DynamicArrayAccess.run(store, &state)?;
-
-        // Inspect the result
-        match result.data {
-            SVD::StorageWrite { key, value } => {
-                assert_eq!(value, input_value);
-
-                match key.data {
-                    SVD::DynamicArrayAccess { slot, index } => {
-                        assert_eq!(index, input_index);
-                        assert_eq!(slot, hash)
-                    }
-                    _ => panic!("Incorrect payload"),
-                }
-            }
-            _ => panic!("Incorrect payload"),
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn lifts_unoptimised_dyn_array_accesses() -> anyhow::Result<()> {
+    fn lifts_dyn_array_accesses() -> anyhow::Result<()> {
         let input_value = SV::new_value(0, Provenance::Synthetic);
         let input_index = SV::new_value(1, Provenance::Synthetic);
         let input_slot = SV::new_known_value(3, KnownWord::from(3), Provenance::Synthetic);

--- a/src/unifier/lift/mod.rs
+++ b/src/unifier/lift/mod.rs
@@ -22,6 +22,7 @@ use crate::{
             dynamic_array_access::DynamicArrayAccess,
             mapping_access::MappingAccess,
             mask_word::MaskWord,
+            recognise_hashed_slots::StorageSlotHashes,
             storage_slots::StorageSlots,
         },
         state::TypingState,
@@ -111,6 +112,7 @@ impl Default for LiftingPasses {
     fn default() -> Self {
         Self {
             passes: vec![
+                StorageSlotHashes::new(),
                 MaskWord::new(),
                 MappingAccess::new(),
                 DynamicArrayAccess::new(),

--- a/src/unifier/state.rs
+++ b/src/unifier/state.rs
@@ -214,7 +214,7 @@ impl Default for TypingState {
 }
 
 /// A type variable represents the possibly-unbound type of an expression.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TypeVariable {
     id: Uuid,
 }
@@ -253,7 +253,7 @@ mod test {
         let value = SymbolicValue::new_value(0, Provenance::Synthetic);
         let type_variable = state.register(value);
 
-        let expression = TypeExpression::default_word();
+        let expression = TypeExpression::word(None, None);
         state.infer(type_variable, expression.clone());
 
         assert_eq!(

--- a/src/vm/data.rs
+++ b/src/vm/data.rs
@@ -1,28 +1,31 @@
 //! This module contains miscellaneous small data-types that are used throughout
 //! the virtual machine.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use crate::error::{container::Locatable, execution, execution::Error};
 
 /// A container that tracks whether an opcode has been visited by the virtual
 /// machine.
 ///
-/// This ensures that we visit all opcodes _exactly once_.
+/// This ensures that we visit all opcodes exactly `iterations_per_opcode`
+/// number of times.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VisitedOpcodes {
-    instructions_len: u32,
-    data:             HashSet<u32>,
+    instructions_len:      u32,
+    iterations_per_opcode: usize,
+    data:                  HashMap<u32, usize>,
 }
 
 impl VisitedOpcodes {
     /// Constructs a new visited opcodes container for up to `instructions_len`
     /// opcodes.
-    pub fn new(instructions_len: u32) -> Self {
-        let data = HashSet::default();
+    pub fn new(instructions_len: u32, iterations_per_opcode: usize) -> Self {
+        let data = HashMap::default();
 
         Self {
             instructions_len,
+            iterations_per_opcode,
             data,
         }
     }
@@ -35,7 +38,10 @@ impl VisitedOpcodes {
     /// in the instruction stream.
     pub fn mark_visited(&mut self, instruction_pointer: u32) -> execution::Result<()> {
         if instruction_pointer < self.instructions_len {
-            self.data.insert(instruction_pointer);
+            self.data
+                .entry(instruction_pointer)
+                .and_modify(|count| *count = count.saturating_add(1))
+                .or_insert(1);
             Ok(())
         } else {
             Err(Error::InstructionPointerOutOfBounds {
@@ -59,7 +65,10 @@ impl VisitedOpcodes {
     /// in the instruction stream.
     pub fn unmark_visited(&mut self, instruction_pointer: u32) -> execution::Result<()> {
         if instruction_pointer < self.instructions_len {
-            self.data.remove(&instruction_pointer);
+            self.data
+                .entry(instruction_pointer)
+                .and_modify(|count| *count = count.saturating_sub(1))
+                .or_insert(0);
             Ok(())
         } else {
             Err(Error::InstructionPointerOutOfBounds {
@@ -76,9 +85,9 @@ impl VisitedOpcodes {
     ///
     /// Returns [`Err`] if the provided `instruction_pointer` is out of bounds
     /// in the instruction stream.
-    pub fn visited(&self, instruction_pointer: u32) -> execution::Result<bool> {
+    pub fn at_visit_limit(&self, instruction_pointer: u32) -> execution::Result<bool> {
         if instruction_pointer < self.instructions_len {
-            Ok(self.data.contains(&instruction_pointer))
+            Ok(self.data.get(&instruction_pointer).unwrap_or(&0) >= &self.iterations_per_opcode)
         } else {
             Err(Error::InstructionPointerOutOfBounds {
                 requested: instruction_pointer as usize,
@@ -96,28 +105,40 @@ mod test {
 
         #[test]
         fn can_mark_instructions_as_visited() -> anyhow::Result<()> {
-            let mut tracker = VisitedOpcodes::new(20);
+            let mut tracker = VisitedOpcodes::new(20, 1);
             tracker.mark_visited(17)?;
 
-            assert!(tracker.visited(17).unwrap());
+            assert!(tracker.at_visit_limit(17).unwrap());
+
+            Ok(())
+        }
+
+        #[test]
+        fn can_visit_instructions_multiple_times() -> anyhow::Result<()> {
+            let mut tracker = VisitedOpcodes::new(20, 3);
+            for _ in 0..3 {
+                tracker.mark_visited(17)?;
+            }
+
+            assert!(tracker.at_visit_limit(17).unwrap());
 
             Ok(())
         }
 
         #[test]
         fn can_unmark_instructions_as_visited() -> anyhow::Result<()> {
-            let mut tracker = VisitedOpcodes::new(20);
+            let mut tracker = VisitedOpcodes::new(20, 1);
             tracker.mark_visited(17)?;
             tracker.unmark_visited(17)?;
 
-            assert!(!tracker.visited(17).unwrap());
+            assert!(!tracker.at_visit_limit(17).unwrap());
 
             Ok(())
         }
 
         #[test]
         fn cannot_mark_invalid_instructions_as_visited() -> anyhow::Result<()> {
-            let mut tracker = VisitedOpcodes::new(20);
+            let mut tracker = VisitedOpcodes::new(20, 1);
             let mark = tracker
                 .mark_visited(1000)
                 .expect_err("Impossible instruction was marked as visited.");
@@ -135,7 +156,7 @@ mod test {
 
         #[test]
         fn cannot_unmark_invalid_instructions_as_visited() -> anyhow::Result<()> {
-            let mut tracker = VisitedOpcodes::new(20);
+            let mut tracker = VisitedOpcodes::new(20, 1);
             let mark = tracker
                 .unmark_visited(1000)
                 .expect_err("Impossible instruction was marked as visited.");

--- a/src/vm/state/mod.rs
+++ b/src/vm/state/mod.rs
@@ -52,13 +52,13 @@ pub struct VMState {
 impl VMState {
     /// Constructs a new virtual machine state originating at the provided
     /// `fork_point`, with all memory locations set to their default values.
-    pub fn new(fork_point: u32, instructions_len: u32) -> Self {
+    pub fn new(fork_point: u32, instructions_len: u32, iterations_per_opcode: usize) -> Self {
         let stack = Stack::new();
         let memory = Memory::new();
         let storage = Storage::new();
         let recorded_values = Vec::default();
         let logged_values = Vec::default();
-        let visited_instructions = VisitedOpcodes::new(instructions_len);
+        let visited_instructions = VisitedOpcodes::new(instructions_len, iterations_per_opcode);
 
         Self {
             fork_point,
@@ -73,8 +73,8 @@ impl VMState {
 
     /// Creates a new virtual machine state originating at the start of
     /// execution, with all memory locations set to their default values.
-    pub fn new_at_start(instructions_len: u32) -> Self {
-        Self::new(0, instructions_len)
+    pub fn new_at_start(instructions_len: u32, iterations_per_opcode: usize) -> Self {
+        Self::new(0, instructions_len, iterations_per_opcode)
     }
 
     /// Gets the stack associated with this virtual machine state.
@@ -179,20 +179,23 @@ impl VMState {
 
 #[cfg(test)]
 mod test {
-    use crate::vm::{
-        state::VMState,
-        value::{SymbolicValue, SymbolicValueData},
+    use crate::{
+        constant::DEFAULT_ITERATIONS_PER_OPCODE,
+        vm::{
+            state::VMState,
+            value::{SymbolicValue, SymbolicValueData},
+        },
     };
 
     #[test]
     fn can_construct_vm_state() {
-        let state = VMState::new(10, 20);
+        let state = VMState::new(10, 20, DEFAULT_ITERATIONS_PER_OPCODE);
         assert_eq!(state.fork_point(), 10);
     }
 
     #[test]
     fn can_record_symbolic_value() {
-        let mut state = VMState::new_at_start(20);
+        let mut state = VMState::new_at_start(20, DEFAULT_ITERATIONS_PER_OPCODE);
         let value = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
         state.record_value(value.clone());
 
@@ -204,7 +207,7 @@ mod test {
     #[test]
     fn can_fork_state() -> anyhow::Result<()> {
         let value = SymbolicValue::new_synthetic(0, SymbolicValueData::new_value());
-        let state = VMState::new_at_start(200);
+        let state = VMState::new_at_start(200, DEFAULT_ITERATIONS_PER_OPCODE);
         let mut forked_state = state.fork(78);
 
         // The fork points should differ.

--- a/src/vm/thread.rs
+++ b/src/vm/thread.rs
@@ -93,14 +93,20 @@ impl From<VMThread> for VMState {
 
 #[cfg(test)]
 mod test {
-    use crate::vm::{instructions::InstructionStream, state::VMState, thread::VMThread};
+    use crate::{
+        constant::DEFAULT_ITERATIONS_PER_OPCODE,
+        vm::{instructions::InstructionStream, state::VMState, thread::VMThread},
+    };
 
     #[test]
     fn can_fork_vm_thread() -> anyhow::Result<()> {
         let instruction_stream = InstructionStream::try_from(
             vec![0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06].as_slice(),
         )?;
-        let state = VMState::new_at_start(instruction_stream.len() as u32);
+        let state = VMState::new_at_start(
+            instruction_stream.len() as u32,
+            DEFAULT_ITERATIONS_PER_OPCODE,
+        );
         let execution_thread = instruction_stream.new_thread(0)?;
         let mut vm_thread = VMThread::new(state, execution_thread);
 


### PR DESCRIPTION
# Summary

This commit includes the following changes:

- We can now infer the existence of dynamic arrays at a given storage slot.
- Keccak constant discovery is more general, and converts back to the preimage indiscriminately.
- The VM is capable of visiting the opcodes a configurable amount of times.
- Call data chunks now have identity, meaning that two reads of the same size are _not_ equal. This would have caused subtle bugs.

Fixes #33 

# Details

The usual

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
