### PR TITLE
Fully implement unification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { version = "1.3.2", features = ["v4", "fast-rng", "macro-diagnostics"] }
 # These are the dependencies required purely for internal development of the library such as testing or benchmarking.
 [dev-dependencies]
 anyhow = { version = "1.0.71", features = ["backtrace"] }
+itertools = "0.10.5"
 rand = "0.8.5"
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -43,5 +43,14 @@ pub const MAXIMUM_STACK_DEPTH: usize = 1024;
 /// The width of word on the EVM in bits.
 pub const WORD_SIZE: usize = 256;
 
+/// The bit-width of an address type.
+pub const ADDRESS_WIDTH_BITS: usize = 160;
+
+/// The bit-width of a selector type.
+pub const SELECTOR_WIDTH_BITS: usize = 32;
+
+/// The bit-width of a function type.
+pub const FUNCTION_WIDTH_BITS: usize = ADDRESS_WIDTH_BITS + SELECTOR_WIDTH_BITS;
+
 /// The default number of times that the virtual machine will visit each opcode.
 pub const DEFAULT_ITERATIONS_PER_OPCODE: usize = 10;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -14,16 +14,19 @@ impl Contract {
     /// Creates a new contract from the provided `bytecode` and `chain`.
     ///
     /// This must be the contract bytecode _without_ the CBOR metadata.
+    #[must_use]
     pub fn new(bytecode: Vec<u8>, chain: Chain) -> Self {
         Self { bytecode, chain }
     }
 
     /// Gets a reference to the bytecode of the contract.
+    #[must_use]
     pub fn bytecode(&self) -> &Vec<u8> {
         &self.bytecode
     }
 
     /// Gets a reference to the chain on which the contract is running.
+    #[must_use]
     pub fn chain(&self) -> &Chain {
         &self.chain
     }

--- a/src/error/container.rs
+++ b/src/error/container.rs
@@ -72,22 +72,26 @@ pub struct Errors<E> {
 
 impl<E> Errors<E> {
     /// Creates a new container for errors.
+    #[must_use]
     pub fn new() -> Self {
         let payloads = vec![];
         Self { payloads }
     }
 
     /// Gets the errors contained within this error.
+    #[must_use]
     pub fn payloads(&self) -> &[E] {
         self.payloads.as_slice()
     }
 
     /// Gets the length of the errors container.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.payloads.len()
     }
 
     /// Checks if the errors container is empty.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -99,12 +103,12 @@ where
 {
     /// Adds the provided `error` to the container.
     pub fn add(&mut self, error: E) {
-        self.payloads.push(error)
+        self.payloads.push(error);
     }
 
     /// Adds the multiple provided errors to the container.
     pub fn add_many(&mut self, errors: impl Into<Vec<E>>) {
-        self.payloads.extend(errors.into())
+        self.payloads.extend(errors.into());
     }
 }
 
@@ -190,8 +194,8 @@ where
             write!(f, "Encountered no errors")?;
         } else {
             writeln!(f, "Encountered {} errors:", self.payloads.len())?;
-            for error in self.payloads.iter() {
-                writeln!(f, "{}", error)?;
+            for error in &self.payloads {
+                writeln!(f, "{error}")?;
             }
         }
 

--- a/src/error/disassembly.rs
+++ b/src/error/disassembly.rs
@@ -18,9 +18,6 @@ pub enum Error {
     #[error("Invalid stack item {item:?} provided for the `{name}` opcode")]
     InvalidStackItem { item: u8, name: String },
 
-    #[error("{_0:?} is not a valid EVM opcode")]
-    InvalidOpcode(u8),
-
     #[error("Bytecode cannot be empty")]
     EmptyBytecode,
 
@@ -29,6 +26,9 @@ pub enum Error {
 
     #[error("Encountered invalid hex char {_0:?} at index {_1:?}")]
     InvalidHexCharacter(char, usize),
+
+    #[error("The length of the bytecode exceeded {}", u32::MAX)]
+    BytecodeTooLarge,
 }
 
 /// Make it possible to attach locations to these errors.

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -133,7 +133,7 @@ impl From<unification::LocatedError> for Errors {
 impl From<execution::Errors> for Errors {
     fn from(value: execution::Errors) -> Self {
         let errs: Vec<execution::LocatedError> = value.into();
-        let new_errs: Vec<LocatedError> = errs.into_iter().map(|e| e.into()).collect();
+        let new_errs: Vec<LocatedError> = errs.into_iter().map(std::convert::Into::into).collect();
 
         new_errs.into()
     }
@@ -144,7 +144,7 @@ impl From<execution::Errors> for Errors {
 impl From<unification::Errors> for Errors {
     fn from(value: unification::Errors) -> Self {
         let errs: Vec<unification::LocatedError> = value.into();
-        let new_errs: Vec<LocatedError> = errs.into_iter().map(|e| e.into()).collect();
+        let new_errs: Vec<LocatedError> = errs.into_iter().map(std::convert::Into::into).collect();
 
         new_errs.into()
     }

--- a/src/error/unification.rs
+++ b/src/error/unification.rs
@@ -3,7 +3,14 @@
 
 use thiserror::Error;
 
-use crate::{error::container, unifier::expression::TypeExpression, vm::value::BoxedVal};
+use crate::{
+    error::container,
+    unifier::{
+        expression::{InferenceSet, TypeExpression},
+        state::TypeVariable,
+    },
+    vm::value::BoxedVal,
+};
 
 /// Errors that occur during unification and type inference process in the
 /// [`crate::unifier::Unifier`].
@@ -14,6 +21,15 @@ pub enum Error {
 
     #[error("Invalid typing expression {value:?} encountered during unification: {reason}")]
     InvalidInference { value: TypeExpression, reason: String },
+
+    #[error("Unification is not complete for {var:?}, found multiple inferences: {inferences:?}")]
+    UnificationIncomplete { var: TypeVariable, inferences: InferenceSet },
+
+    #[error("Type variable {var:?} has no associated inferences")]
+    UnificationFailure { var: TypeVariable },
+
+    #[error("Tried to convert {value} to fit in size {width} but it was too large")]
+    OverSizedNumber { value: i128, width: usize },
 }
 
 /// Make it possible to attach locations to these errors.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -12,12 +12,13 @@ pub struct StorageLayout {
 
 impl StorageLayout {
     /// Adds a slot specified by `index` and `typ` to the storage layout.
-    pub fn add(&mut self, index: usize, typ: AbiType) {
-        let slot = StorageSlot::new(index, typ);
+    pub fn add(&mut self, index: usize, typ: AbiType, defaulted: bool) {
+        let slot = StorageSlot::new(index, typ, defaulted);
         self.slots.push(slot);
     }
 
     /// Gets the storage slots that make up this layout.
+    #[must_use]
     pub fn slots(&self) -> &Vec<StorageSlot> {
         &self.slots
     }
@@ -38,12 +39,20 @@ pub struct StorageSlot {
 
     /// The best-known type of the storage slot.
     pub typ: AbiType,
+
+    /// A flag indicating if any defaulting took place while computing `typ`.
+    pub defaulted: bool,
 }
 
 impl StorageSlot {
     /// Constructs a new storage slot container for the data at `index` with
     /// type `typ`.
-    pub fn new(index: usize, typ: AbiType) -> Self {
-        Self { index, typ }
+    #[must_use]
+    pub fn new(index: usize, typ: AbiType, defaulted: bool) -> Self {
+        Self {
+            index,
+            typ,
+            defaulted,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!     PushN::new(1, vec![0x00]).unwrap(), // Value to store
 //!     PushN::new(1, vec![0x00]).unwrap(), // Key under which to store it
 //!     SStore,                             // Storage
-//!     Invalid,                            // Return from this thread with invalid instruction
+//!     Invalid::default(),                 // Return from this thread with invalid instruction
 //!     JumpDest,                           // The destination for the jump
 //!     PushN::new(1, vec![0xff]).unwrap(), // The value to store into memory
 //!     PushN::new(1, vec![0x00]).unwrap(), // The offset in memory to store it at
@@ -73,7 +73,8 @@
 //! assert_eq!(layout.slots().len(), 1);
 //! ```
 
-#![warn(clippy::all, clippy::cargo)]
+#![warn(clippy::all, clippy::cargo, clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)] // Allows for better API naming
 
 pub mod analyzer;
 pub mod constant;

--- a/src/opcode/environment.rs
+++ b/src/opcode/environment.rs
@@ -1006,6 +1006,7 @@ impl LogN {
     }
 
     /// Gets the number of topics passed to this log call.
+    #[must_use]
     pub fn n(&self) -> u8 {
         self.topic_count
     }
@@ -1021,7 +1022,7 @@ impl Opcode for LogN {
         let offset = stack.pop()?;
         let size = stack.pop()?;
         let mut topics: Vec<BoxedVal> = Vec::new();
-        let upper_bound = self.n() as u32 + 2;
+        let upper_bound = u32::from(self.n()) + 2;
         for _ in 2..upper_bound {
             topics.push(stack.pop()?);
         }
@@ -1678,7 +1679,7 @@ mod test {
             let input_size = SymbolicValue::new_synthetic(1, SymbolicValueData::new_value());
             let stored_data = SymbolicValue::new_synthetic(2, SymbolicValueData::new_value());
 
-            for i in 0..topic_count as u32 {
+            for i in 0..u32::from(topic_count) {
                 let value = SymbolicValue::new_synthetic(3 + i, SymbolicValueData::new_value());
                 topics.push(value);
             }
@@ -1810,7 +1811,7 @@ mod test {
         assert_eq!(value.provenance, Provenance::Execution);
         match &value.data {
             SymbolicValueData::SelfDestruct { target } => {
-                assert_eq!(target, &input_address)
+                assert_eq!(target, &input_address);
             }
             _ => panic!("Invalid payload"),
         }

--- a/src/opcode/logic.rs
+++ b/src/opcode/logic.rs
@@ -569,6 +569,7 @@ impl Opcode for Not {
 pub struct Byte;
 
 impl Opcode for Byte {
+    #[allow(clippy::similar_names)] // They are accurate names
     fn execute(&self, vm: &mut VM) -> ExecuteResult {
         // Get the stack and the env data
         let instruction_pointer = vm.instruction_pointer()?;
@@ -1166,7 +1167,7 @@ mod test {
                                         assert_eq!(
                                             value,
                                             &KnownWord::from(0xf8u8.to_le_bytes().to_vec(),)
-                                        )
+                                        );
                                     }
                                     _ => panic!("Invalid payload"),
                                 }
@@ -1185,7 +1186,7 @@ mod test {
                                                 assert_eq!(
                                                     value,
                                                     &KnownWord::from(0x08u8.to_le_bytes().to_vec())
-                                                )
+                                                );
                                             }
                                             _ => panic!("Invalid payload"),
                                         }

--- a/src/opcode/mod.rs
+++ b/src/opcode/mod.rs
@@ -120,7 +120,7 @@ mod test_util {
     }
 
     /// Constructs a new virtual machine with the provided `instructions` and
-    /// with the provided values` pushed onto its stack in order.
+    /// with the provided `values` pushed onto its stack in order.
     ///
     /// This means that the last item in `values` will be put on the top of
     /// the stack.
@@ -134,9 +134,9 @@ mod test_util {
         let stack = vm.state()?.stack_mut();
 
         let values_len = values.len();
-        values.into_iter().for_each(|val| {
+        for val in values {
             stack.push(val).expect("Failed to insert value into stack");
-        });
+        }
 
         // Check that we have constructed the stack correctly
         assert_eq!(stack.depth(), values_len);

--- a/src/opcode/util.rs
+++ b/src/opcode/util.rs
@@ -31,7 +31,7 @@ use crate::{
 ///
 /// It is assumed that all errors returned by this function are instances of
 /// [`VMError`].
-#[allow(clippy::boxed_local)]
+#[allow(clippy::boxed_local)] // We always pass around boxed values during execution
 pub fn validate_jump_destination(counter: &BoxedVal, vm: &mut VM) -> execution::Result<u32> {
     let instruction_pointer = vm.instruction_pointer()?;
     let jump_target = match &counter.clone().constant_fold().data {

--- a/src/unifier/abi.rs
+++ b/src/unifier/abi.rs
@@ -3,6 +3,8 @@
 
 use ethnum::U256;
 
+use crate::unifier::expression::TypeExpression;
+
 /// Concretely known Solidity ABI types.
 ///
 /// # Invariants
@@ -62,4 +64,19 @@ pub enum AbiType {
 
     /// A mapping from `key_tp` to `val_tp`.
     Mapping { key_tp: Box<AbiType>, val_tp: Box<AbiType> },
+
+    /// A type in the unifier that resolved to an infinite loop of type
+    /// variables.
+    InfiniteType,
+
+    /// A type that could not be concretely resolved due to conflicting
+    /// evidence.
+    ///
+    /// While the conflict is not usually useful itself, treating them as types
+    /// ensures that we still complete unification as well as is possible.
+    ConflictedType {
+        left:   TypeExpression,
+        right:  TypeExpression,
+        reason: String,
+    },
 }

--- a/src/unifier/expression.rs
+++ b/src/unifier/expression.rs
@@ -8,7 +8,10 @@ use std::collections::HashSet;
 
 use ethnum::U256;
 
-use crate::unifier::{abi::AbiType, state::TypeVariable};
+use crate::{
+    constant::{ADDRESS_WIDTH_BITS, FUNCTION_WIDTH_BITS, SELECTOR_WIDTH_BITS},
+    unifier::state::TypeVariable,
+};
 
 /// An alias recommended for use when you have to write it out often.
 pub type TE = TypeExpression;
@@ -36,6 +39,9 @@ pub enum TypeExpression {
         /// Set to [`None`] if the signedness is unknown. Otherwise set to
         /// `true` if signed, and `false` if unsigned.
         signed: Option<bool>,
+
+        /// Any special way that the word has been used.
+        usage: WordUse,
     },
 
     /// A static array containing items of type `element` and with `length`.
@@ -47,43 +53,204 @@ pub enum TypeExpression {
     /// A dynamic array containing items with the type of `element`.
     DynamicArray { element: TypeVariable },
 
-    /// A type that has been concretely resolved to an EVM type.
-    ConcreteType { ty: AbiType },
+    /// A representation of knowing nothing about the type.
+    Any,
+
+    /// A representation of two conflicting pieces of evidence.
+    Conflict {
+        left:   Box<TypeExpression>,
+        right:  Box<TypeExpression>,
+        reason: String,
+    },
 }
 
 impl TypeExpression {
-    /// Constructs a word with the provided `width` and `size`.
-    pub fn word(width: Option<usize>, signed: Option<bool>) -> Self {
-        Self::Word { width, signed }
+    /// Constructs a word with the provided `width` and `signed`.
+    #[must_use]
+    pub fn word(width: Option<usize>, signed: Option<bool>, usage: WordUse) -> Self {
+        Self::Word {
+            width,
+            signed,
+            usage,
+        }
+    }
+
+    /// Creates a word with no known `width` or `signed`ness.
+    #[must_use]
+    pub fn default_word() -> Self {
+        Self::word(None, None, WordUse::default())
     }
 
     /// Constructs an unsigned word with the provided `width`.
+    #[must_use]
     pub fn unsigned_word(width: Option<usize>) -> Self {
         let signed = Some(false);
-        Self::Word { width, signed }
+        Self::word(width, signed, WordUse::None)
     }
 
     /// Constructs a signed word with the provided `width`.
+    #[must_use]
     pub fn signed_word(width: Option<usize>) -> Self {
         let signed = Some(true);
-        Self::Word { width, signed }
+        Self::word(width, signed, WordUse::None)
+    }
+
+    /// Constructs a word that has been used as a boolean.
+    #[must_use]
+    pub fn bool() -> Self {
+        Self::word(None, None, WordUse::Bool)
+    }
+
+    /// Constructs a word that has been used as an address.
+    #[must_use]
+    pub fn address() -> Self {
+        let width = Some(ADDRESS_WIDTH_BITS);
+        let signed = Some(false);
+        Self::word(width, signed, WordUse::Address)
+    }
+
+    /// Constructs a word that has been used as a selector.
+    #[must_use]
+    pub fn selector() -> Self {
+        let width = Some(SELECTOR_WIDTH_BITS);
+        let signed = Some(false);
+        Self::word(width, signed, WordUse::Selector)
+    }
+
+    /// Constructs a word that has been used as a function.
+    #[must_use]
+    pub fn function() -> Self {
+        let width = Some(FUNCTION_WIDTH_BITS);
+        let signed = Some(false);
+        Self::word(width, signed, WordUse::Function)
     }
 
     /// Constructs an equality wrapping the provided type variable `id`.
+    #[must_use]
     pub fn eq(id: TypeVariable) -> Self {
         Self::Equal { id }
     }
 
     /// Constructs a new mapping wrapping the `key` and `value` types.
+    #[must_use]
     pub fn mapping(key: TypeVariable, value: TypeVariable) -> Self {
         Self::Mapping { key, value }
     }
 
     /// Constructs a new dynamic array wrapping the `element` type.
+    #[must_use]
     pub fn dyn_array(element: TypeVariable) -> Self {
         Self::DynamicArray { element }
+    }
+
+    /// Creates a type expression representing a conflict of the `left` and
+    /// `right` expressions due to `reason`.
+    pub fn conflict(left: Self, right: Self, reason: impl Into<String>) -> Self {
+        let left = Box::new(left);
+        let right = Box::new(right);
+        let reason = reason.into();
+        Self::Conflict {
+            left,
+            right,
+            reason,
+        }
+    }
+
+    /// Returns `true` if `self` is a type constructor, otherwise returns
+    /// `false`.
+    #[must_use]
+    pub fn is_type_constructor(&self) -> bool {
+        match self {
+            Self::Any | Self::Word { .. } | Self::Conflict { .. } => false,
+            Self::FixedArray { .. }
+            | Self::Mapping { .. }
+            | Self::DynamicArray { .. }
+            | Self::Equal { .. } => true,
+        }
     }
 }
 
 /// A set of typing judgements.
 pub type InferenceSet = HashSet<TypeExpression>;
+
+/// A representation of the special ways in which a word could be used.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum WordUse {
+    /// The word has no special use.
+    None,
+
+    /// The word has been used specifically as a boolean (the result of
+    /// `ISZERO`).
+    Bool,
+
+    /// The word has been used as the address of a contract.
+    Address,
+
+    /// The word has been used as a selector.
+    Selector,
+
+    /// The word has been used as a function (an address followed by a
+    /// selector).
+    Function,
+
+    /// Conflicting usages found.
+    Conflict { conflicts: Vec<WordUse> },
+}
+
+impl WordUse {
+    /// Adds a conflict with `other` for `self`.
+    #[must_use]
+    pub fn conflict(self, other: Self) -> Self {
+        match self {
+            Self::Conflict { mut conflicts } => match other {
+                Self::Conflict {
+                    conflicts: other_conflicts,
+                } => {
+                    conflicts.extend(other_conflicts);
+                    Self::Conflict { conflicts }
+                }
+                other => {
+                    conflicts.push(other);
+                    Self::Conflict { conflicts }
+                }
+            },
+            this => match other {
+                Self::Conflict { mut conflicts } => {
+                    conflicts.push(this);
+                    Self::Conflict { conflicts }
+                }
+                other => Self::Conflict {
+                    conflicts: vec![this, other],
+                },
+            },
+        }
+    }
+
+    /// Creates a usage conflict of `left` and `right`.
+    #[must_use]
+    pub fn conflict_of(left: Self, other: Self) -> Self {
+        left.conflict(other)
+    }
+
+    /// Merges two usages if they are compatible, or returns a conflict if not.
+    #[must_use]
+    pub fn merge(self, other: Self) -> Self {
+        if self == other {
+            return self;
+        }
+
+        match (self, other) {
+            // None can always merge with the other
+            (Self::None, other) | (other, Self::None) => other,
+
+            // If they aren't equal, then we have a conflict
+            (l, r) => l.conflict(r),
+        }
+    }
+}
+
+impl Default for WordUse {
+    fn default() -> Self {
+        Self::None
+    }
+}

--- a/src/unifier/inference_rule/dynamic_array_write.rs
+++ b/src/unifier/inference_rule/dynamic_array_write.rs
@@ -26,6 +26,7 @@ use crate::{
 pub struct DynamicArrayWriteRule;
 
 impl InferenceRule for DynamicArrayWriteRule {
+    #[allow(clippy::many_single_char_names)] // They correspond to the above spec
     fn infer(
         &self,
         value: &BoxedVal,
@@ -116,7 +117,8 @@ mod test {
         DynamicArrayWriteRule.infer(&store, a_tv, &mut state)?;
 
         // Check that we end up with expected results in the state
-        assert!(state.inferences(g_tv).is_empty());
+        assert_eq!(state.inferences(g_tv).len(), 1);
+        assert!(state.inferences(g_tv).contains(&TE::eq(b_tv)));
 
         assert_eq!(state.inferences(f_tv).len(), 1);
         assert!(state.inferences(f_tv).contains(&TE::unsigned_word(None)));

--- a/src/unifier/inference_rule/mod.rs
+++ b/src/unifier/inference_rule/mod.rs
@@ -70,6 +70,7 @@ pub struct InferenceRules {
 
 impl InferenceRules {
     /// Constructs a new container for inference rules.
+    #[must_use]
     pub fn new() -> Self {
         let rules = HashSet::new();
         Self { rules }
@@ -99,8 +100,8 @@ impl InferenceRules {
         ty_var: TypeVariable,
         state: &mut TypingState,
     ) -> Result<()> {
-        for rule in self.rules.iter() {
-            rule.infer(value, ty_var, state)?
+        for rule in &self.rules {
+            rule.infer(value, ty_var, state)?;
         }
 
         Ok(())

--- a/src/unifier/lift/dynamic_array_access.rs
+++ b/src/unifier/lift/dynamic_array_access.rs
@@ -27,6 +27,7 @@ use crate::{
 pub struct DynamicArrayAccess;
 
 impl DynamicArrayAccess {
+    #[must_use]
     pub fn new() -> Box<Self> {
         Box::new(Self)
     }

--- a/src/unifier/lift/mapping_access.rs
+++ b/src/unifier/lift/mapping_access.rs
@@ -18,6 +18,7 @@ pub struct MappingAccess;
 
 impl MappingAccess {
     /// Constructs a new instance of the mapping access lifting pass.
+    #[must_use]
     pub fn new() -> Box<Self> {
         Box::new(Self)
     }

--- a/src/unifier/lift/mask_word.rs
+++ b/src/unifier/lift/mask_word.rs
@@ -22,6 +22,7 @@ pub struct MaskWord;
 
 impl MaskWord {
     /// Constructs a new instance of the word mask lifting pass.
+    #[must_use]
     pub fn new() -> Box<Self> {
         Box::new(Self)
     }
@@ -133,7 +134,7 @@ mod test {
         let input_value = SymbolicValue::new_value(4, Provenance::Synthetic);
         let input_mask = SymbolicValue::new_known_value(
             0,
-            KnownWord::from(0x0000ffff0000),
+            KnownWord::from(0x0000_ffff_0000),
             Provenance::Synthetic,
         );
         let and = SymbolicValue::new(
@@ -151,7 +152,7 @@ mod test {
         match &result.data {
             SVD::WordMask { value, mask } => {
                 assert_eq!(value, &input_value);
-                assert_eq!(*mask, 0x0000ffff0000);
+                assert_eq!(*mask, 0x0000_ffff_0000);
             }
             _ => panic!("Incorrect payload"),
         };

--- a/src/unifier/lift/mod.rs
+++ b/src/unifier/lift/mod.rs
@@ -76,6 +76,7 @@ impl LiftingPasses {
 
     /// Gets a reference to the pass of the given type, if it exists in the
     /// passes container.
+    #[must_use]
     pub fn get<P: Lift>(&self) -> Option<&P> {
         self.passes
             .iter()
@@ -100,7 +101,7 @@ impl LiftingPasses {
     ///
     /// Returns [`Err`] if any of the passes error.
     pub fn run(&mut self, mut value: BoxedVal, state: &TypingState) -> Result<BoxedVal> {
-        for pass in self.passes.iter_mut() {
+        for pass in &mut self.passes {
             value = pass.run(value, state)?;
         }
 

--- a/src/unifier/lift/storage_slots.rs
+++ b/src/unifier/lift/storage_slots.rs
@@ -22,6 +22,7 @@ pub struct StorageSlots;
 
 impl StorageSlots {
     /// Constructs a new instance of the storage slot access lifting pass.
+    #[must_use]
     pub fn new() -> Box<Self> {
         Box::new(Self)
     }
@@ -114,7 +115,7 @@ mod test {
                 assert_eq!(key, mapping_key);
                 match slot.data {
                     SVD::StorageSlot { key } => {
-                        assert_eq!(key, slot_index_constant)
+                        assert_eq!(key, slot_index_constant);
                     }
                     _ => panic!("Incorrect payload"),
                 }
@@ -165,7 +166,7 @@ mod test {
                         assert_eq!(key, mapping_key);
                         match slot.data {
                             SVD::StorageSlot { key } => {
-                                assert_eq!(key, slot_index_constant)
+                                assert_eq!(key, slot_index_constant);
                             }
                             _ => panic!("Incorrect payload"),
                         }

--- a/src/unifier/unification/data.rs
+++ b/src/unifier/unification/data.rs
@@ -1,0 +1,176 @@
+//! This module contains data structures used in the implementation of the
+//! unifier.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    hash::{BuildHasher, Hash},
+};
+
+/// An specialised implementation of the
+/// [Disjoint Set](https://en.wikipedia.org/wiki/Disjoint-set_data_structure)
+/// data structure that is capable of carrying arbitrary auxiliary data along
+/// with the values in the tree.
+///
+/// # Performance
+///
+/// The implementation of [`Self::find`] could be improved in efficiency. This
+/// is left as future work, but can be done by allowing `find` to optimise the
+/// forest as it does its work.
+///
+/// Similarly, this implementation currently makes liberal use of cloning.
+/// Ideally it would instead rely on interior mutability as much as possible,
+/// but this is an optimisation for the future.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DisjointSet<Value, Data>
+where
+    Value: Clone + Debug + Eq + Hash + PartialEq,
+    Data: Combine + Debug + Eq + PartialEq,
+{
+    reps: HashMap<Value, Value>,
+    data: HashMap<Value, Data>,
+}
+
+impl<Value, Data> DisjointSet<Value, Data>
+where
+    Value: Clone + Debug + Eq + Hash + PartialEq,
+    Data: Combine + Debug + Eq + PartialEq,
+{
+    /// Constructs a new union-find forest structure
+    #[must_use]
+    pub fn new() -> Self {
+        let reps = HashMap::new();
+        let data = HashMap::new();
+        Self { reps, data }
+    }
+
+    /// Inserts the `value` into the data structure.
+    pub fn insert(&mut self, value: Value) {
+        self.reps.insert(value.clone(), value);
+    }
+
+    /// Finds the root element corresponding to the query `value`.
+    pub fn find(&mut self, value: &Value) -> Value {
+        if let Some(rep) = self.reps.get(value).cloned() {
+            if rep == *value {
+                value.clone()
+            } else {
+                let f = self.find(&rep);
+                self.reps.insert(value.clone(), f.clone());
+                f
+            }
+        } else {
+            self.reps.insert(value.clone(), value.clone());
+            self.find(value)
+        }
+    }
+
+    /// Merges the set containing `v1` with the set containing `v2`, using
+    /// [`Self::find`] to first find the roots.
+    pub fn union(&mut self, v1: &Value, v2: &Value) {
+        let v1 = self.find(v1);
+        let v2 = self.find(v2);
+        let v1_val = self.data.get(&v1).cloned().unwrap_or(Data::identity());
+        let v2_val = self.data.remove(&v2).unwrap_or(Data::identity());
+        self.data.insert(v1.clone(), v1_val.combine(v2_val));
+        self.reps.insert(v2, v1);
+    }
+
+    /// Associates the provided auxiliary `data` with `value`,
+    /// [`Combine::combine`]ing it with any previous data.
+    pub fn add_data(&mut self, value: &Value, data: Data) {
+        let root = self.find(value);
+        let previous_data = self.data.remove(&root).unwrap_or(Data::identity());
+        self.data.insert(root.clone(), previous_data.combine(data));
+    }
+
+    /// Gets the auxiliary data corresponding to the passed `value`, if it
+    /// exists, or [`None`] otherwise.
+    pub fn get_data(&mut self, value: &Value) -> Option<&Data> {
+        let root = self.find(value);
+        self.data.get(&root)
+    }
+
+    /// Sets the provided auxiliary `data` for `value`, replacing
+    pub fn set_data(&mut self, value: &Value, data: Data) {
+        let root = self.find(value);
+        self.data.insert(root, data);
+    }
+}
+
+impl<Value, Data> DisjointSet<Value, Data>
+where
+    Value: Clone + Debug + Eq + Hash + PartialEq,
+    Data: Combine + Debug + Default + Eq + PartialEq,
+{
+    /// Gets all of the individual sets in the forest.
+    pub fn sets(&mut self) -> Vec<(Value, Data)> {
+        self.reps
+            .iter()
+            .filter(|(k, v)| k == v)
+            .map(|(k, _)| (k.clone(), self.data.entry(k.clone()).or_default().clone()))
+            .collect()
+    }
+}
+
+impl<Value, Data> Default for DisjointSet<Value, Data>
+where
+    Value: Clone + Debug + Eq + Hash + PartialEq,
+    Data: Combine + Debug + Eq + PartialEq,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A trait that represents types that can be combined in some way.
+///
+/// This is equivalent to a monoid.
+pub trait Combine
+where
+    Self: Clone,
+{
+    /// The combination function itself.
+    ///
+    /// The function should be:
+    ///
+    /// - **Symmetric** (such that `a.combine(b) == b.combine(a)`)
+    /// - **Associative** (such that `a.combine(b.combine(c) ==
+    ///   (a.combine(b)).combine(c)`).
+    #[must_use]
+    fn combine(self, other: Self) -> Self;
+
+    /// An element `a` that, when combined (`a.combine(b)`) with another element
+    /// `b` produces `b`.
+    #[must_use]
+    fn identity() -> Self;
+}
+
+impl<A: Combine> Combine for Option<A> {
+    fn combine(self, other: Self) -> Self {
+        match (self, other) {
+            (Some(a), Some(b)) => Some(a.combine(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        }
+    }
+
+    fn identity() -> Self {
+        None
+    }
+}
+
+impl<A, S> Combine for HashSet<A, S>
+where
+    A: Clone + Eq + Hash + PartialEq,
+    S: BuildHasher + Clone + Default,
+{
+    fn combine(self, other: Self) -> Self {
+        self.union(&other).cloned().collect()
+    }
+
+    fn identity() -> Self {
+        HashSet::default()
+    }
+}

--- a/src/unifier/unification/mod.rs
+++ b/src/unifier/unification/mod.rs
@@ -1,0 +1,911 @@
+//! This module contains functionality for performing unification of inferences.
+//!
+//! It is split off from the primary [`super::Unifier`] itself to enable re-use
+//! of the functionality elsewhere, and also enable easier testing without
+//! needing to spool up the entire unifier.
+
+pub mod data;
+use std::collections::{HashSet, VecDeque};
+
+use crate::unifier::{
+    expression::{InferenceSet, TypeExpression, TE},
+    state::{TypeVariable, TypingState},
+    unification::data::DisjointSet,
+};
+
+/// The concrete type of the [`DisjointSet`] data structure used for type
+/// inference and unification.
+pub type UnificationForest = DisjointSet<TypeVariable, InferenceSet>;
+
+/// Performs unification to resolve the most-concrete type for all type
+/// variables in the typing `state`, writing the unification result into the
+/// state.
+///
+/// This may result in [`TE::Conflict`]s occurring in the result forest.
+pub fn unify(state: &mut TypingState) {
+    // First we have to create our forest.
+    let mut forest = UnificationForest::new();
+
+    // Populating it first inserts all variables into the forest.
+    for var in state.variables() {
+        forest.insert(var);
+    }
+
+    // And then resolves all equalities by using the union operation to combine
+    // possibly-disjoint sets to create inference sets.
+    for type_var in state.variables() {
+        for type_expr in state.inferences(type_var) {
+            match type_expr {
+                TypeExpression::Equal { id } => forest.union(&type_var, id),
+                _ => forest.add_data(&type_var, HashSet::from([type_expr.clone()])),
+            };
+        }
+    }
+
+    // Then, we loop until we stop making progress.
+    loop {
+        // Create the set of new equalities.
+        let mut all_equalities: HashSet<Equality> = HashSet::new();
+
+        // Create our stop condition.
+        let mut made_progress = false;
+
+        for (ty_var, inferences) in forest.sets() {
+            // If there are no inferences for this type variable, go to the next one.
+            if inferences.is_empty() {
+                continue;
+            }
+
+            // Get all of the inferences
+            let mut inferred_expressions: VecDeque<_> = inferences.into_iter().collect();
+            let mut current = inferred_expressions.pop_front().unwrap_or_else(|| {
+                unreachable!("We know there is at least one item in the expressions queue")
+            });
+
+            // If there is more than one expression, this will execute, and fold over them
+            for expression in inferred_expressions {
+                made_progress = true;
+                let Merge {
+                    expression,
+                    equalities,
+                } = merge(current.clone(), expression);
+                current = expression;
+                all_equalities.extend(equalities);
+            }
+
+            // Finally, we have to update the forest's inferences for each type variable
+            forest.set_data(&ty_var, InferenceSet::from([current]));
+        }
+
+        // When we get to the end of that loop, we need to compute the unions of
+        // the variables with their new associated inferences
+        for Equality { left, right } in all_equalities {
+            forest.union(&left, &right);
+        }
+
+        // If we didn't make any progress at any point, then we end the loop as we are
+        // done with unification
+        if !made_progress {
+            break;
+        }
+    }
+
+    state.set_result(forest);
+}
+
+/// Combines `left` with `right` to produce a new type expression.
+///
+/// # Panics
+///
+/// This function will panic if passed a [`TE::Equal`] expression, as its
+/// preconditions state that no such equalities should exist by the point of
+/// unification.
+#[allow(clippy::match_same_arms)] // The ordering of the arms matters
+#[allow(clippy::too_many_lines)] // It needs to remain one function
+#[must_use]
+pub fn merge(left: TE, right: TE) -> Merge {
+    // If they are equal there's no combining to do
+    if left == right {
+        return Merge::expression(left);
+    }
+
+    match (&left, &right) {
+        // If equalities exist here we have an actual error as it indicates a likely bug in the
+        // unifier
+        (TE::Equal { .. }, _) => panic!(
+            "Equalities should not exist when unifying, but found: {:?}",
+            left.clone()
+        ),
+        (_, TE::Equal { .. }) => panic!(
+            "Equalities should not exist when unifying, but found: {:?}",
+            right.clone()
+        ),
+
+        // Combining a conflict with anything is just the conflict
+        (TE::Conflict { .. }, _) => Merge::expression(left),
+        (_, TE::Conflict { .. }) => Merge::expression(right),
+
+        // Combining words with words is complex
+        (
+            TE::Word {
+                width: width_l,
+                signed: signed_l,
+                usage: usage_l,
+            },
+            TE::Word {
+                width: width_r,
+                signed: signed_r,
+                usage: usage_r,
+            },
+        ) => {
+            // `and_then` and `map` don't work with Result, so we get this monstrosity
+            let width = match (width_l, width_r) {
+                (Some(l), Some(r)) if l == r => Some(*l),
+                (Some(_), Some(_)) => {
+                    return Merge::expression(TE::conflict(
+                        left,
+                        right,
+                        "Disagreeing numeric widths",
+                    ));
+                }
+                (Some(l), _) => Some(*l),
+                (_, Some(r)) => Some(*r),
+                (None, None) => None,
+            };
+
+            let signed = match (signed_l, signed_r) {
+                (Some(l), Some(r)) if l == r => Some(*l),
+                (Some(_), Some(_)) => {
+                    return Merge::expression(TE::conflict(
+                        left,
+                        right,
+                        "Disagreeing numeric signedness",
+                    ));
+                }
+                (Some(l), _) => Some(*l),
+                (_, Some(r)) => Some(*r),
+                (None, None) => None,
+            };
+
+            Merge::expression(TE::word(
+                width,
+                signed,
+                usage_l.clone().merge(usage_r.clone()),
+            ))
+        }
+
+        // To combine a word with a dynamic array we delegate
+        (TE::Word { .. }, TE::DynamicArray { .. }) => merge(right, left),
+
+        // They produce a dynamic array as long as the word is not signed
+        (TE::DynamicArray { .. }, TE::Word { signed, .. }) => Merge::expression(match signed {
+            Some(false) | None => left,
+            _ => TE::conflict(left, right, "An array cannot have signed length"),
+        }),
+
+        // Dynamic arrays can combine with dynamic arrays
+        (TE::DynamicArray { element: element_l }, TE::DynamicArray { element: element_r }) => {
+            let equalities = vec![Equality::new(*element_l, *element_r)];
+            Merge::new(left, equalities)
+        }
+
+        // Fixed arrays can combine with fixed arrays
+        (
+            TE::FixedArray {
+                element: element_l,
+                length: length_l,
+            },
+            TE::FixedArray {
+                element: element_r,
+                length: length_r,
+            },
+        ) => {
+            if length_l == length_r {
+                let equalities = vec![Equality::new(*element_l, *element_r)];
+                Merge::new(left, equalities)
+            } else {
+                Merge::expression(TE::conflict(
+                    left,
+                    right,
+                    "Fixed arrays have different lengths",
+                ))
+            }
+        }
+
+        // Mappings can combine with mappings
+        (
+            TE::Mapping {
+                key: key_l,
+                value: value_l,
+            },
+            TE::Mapping {
+                key: key_r,
+                value: value_r,
+            },
+        ) => {
+            // If we get here, the `key_l` and `key_r`, and `value_l` and `value_r` types
+            // were compatible and their inferences have been updated
+            let equalities = vec![
+                Equality::new(*key_l, *key_r),
+                Equality::new(*value_l, *value_r),
+            ];
+            Merge::new(left, equalities)
+        }
+
+        // Everything can combine with `Any` to produce itself, as Any doesn't add information, so
+        // only collapses to `Any` when combined with itself
+        (_, TE::Any) => Merge::expression(left),
+        (TE::Any, _) => Merge::expression(right),
+
+        // Nothing else can combine and be valid, so we error
+        _ => Merge::expression(TE::conflict(left, right, "Incompatible inferences")),
+    }
+}
+
+/// The result from executing [`merge`].
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Merge {
+    /// The expression that results from combining `left` and `right`, which is
+    /// possibly an evidence conflict.
+    pub expression: TypeExpression,
+
+    /// Any new equalities to solve that were created as part of combining
+    /// `left` and `right`.
+    pub equalities: Vec<Equality>,
+}
+
+impl Merge {
+    /// Creates a new combine result from the provided `expression` and
+    /// `equalities`.
+    #[must_use]
+    pub fn new(expression: TypeExpression, equalities: Vec<Equality>) -> Self {
+        Self {
+            expression,
+            equalities,
+        }
+    }
+
+    /// Creates a new combine result from the provided `expression`, with no
+    /// equalities.
+    #[must_use]
+    pub fn expression(expression: TypeExpression) -> Self {
+        let equalities = Vec::new();
+        Self {
+            expression,
+            equalities,
+        }
+    }
+}
+
+/// A representation of a symmetrical equality between two type variables.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Equality {
+    pub left:  TypeVariable,
+    pub right: TypeVariable,
+}
+
+impl Equality {
+    /// Creates a new equality from `left` and `right`.
+    #[must_use]
+    pub fn new(left: TypeVariable, right: TypeVariable) -> Self {
+        Self { left, right }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::panic;
+
+    use ethnum::U256;
+    use itertools::Itertools;
+
+    use crate::{
+        constant::ADDRESS_WIDTH_BITS,
+        unifier::{
+            expression::{WordUse, TE},
+            state::TypingState,
+            unification::{merge, unify},
+        },
+        vm::value::{Provenance, SV},
+    };
+
+    #[test]
+    fn panics_when_encountering_equality() {
+        // Override the panic hook so we don't see output in tests
+        panic::set_hook(Box::new(|_| {}));
+
+        // Set up the state
+        let mut state = TypingState::empty();
+        let v_1 = SV::new_value(0, Provenance::Synthetic);
+        let v_2 = SV::new_value(1, Provenance::Synthetic);
+        state.register(v_1);
+        let v_2_tv = state.register(v_2);
+
+        // Set up some inferences
+        let inference_1 = TE::eq(v_2_tv);
+        let inference_2 = TE::default_word();
+
+        // Check it does the right thing
+        let result = panic::catch_unwind(|| merge(inference_1.clone(), inference_2.clone()));
+        assert!(result.is_err());
+
+        let result = panic::catch_unwind(|| merge(inference_2, inference_1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn can_infer_compatible_unsigned_words() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let v_1 = SV::new_value(0, Provenance::Synthetic);
+        let v_1_tv = state.register(v_1);
+
+        // Set up some inferences
+        let inference_1 = TE::unsigned_word(Some(ADDRESS_WIDTH_BITS));
+        let inference_2 = TE::default_word();
+        let inference_3 = TE::address();
+        let inferences = vec![inference_1, inference_2, inference_3];
+        let inference_permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that they combine properly, and produce the same result no matter the
+        // order
+        for permutation in inference_permutations {
+            permutation.into_iter().for_each(|i| state.infer(v_1_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(v_1_tv, state.result());
+
+            assert!(result.is_some());
+            assert_eq!(
+                result.unwrap(),
+                TE::word(Some(ADDRESS_WIDTH_BITS), Some(false), WordUse::Address)
+            );
+        }
+    }
+
+    #[test]
+    fn can_infer_compatible_signed_words() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let v_1 = SV::new_value(0, Provenance::Synthetic);
+        let v_1_tv = state.register(v_1);
+
+        // Set up some inferences
+        let inference_1 = TE::signed_word(Some(64));
+        let inference_2 = TE::default_word();
+        let inference_3 = TE::bool();
+        let inferences = vec![inference_1, inference_2, inference_3];
+        let inference_permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that they combine properly, and produce the same result no matter the
+        // order
+        for permutation in inference_permutations {
+            permutation.into_iter().for_each(|i| state.infer(v_1_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(v_1_tv, state.result());
+
+            assert!(result.is_some());
+            assert_eq!(
+                result.unwrap(),
+                TE::word(Some(64), Some(true), WordUse::Bool)
+            );
+        }
+    }
+
+    #[test]
+    fn conflicts_for_incompatible_word_evidence() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let v_1 = SV::new_value(0, Provenance::Synthetic);
+        let v_1_ty = state.register(v_1);
+
+        // Set up some inferences
+        let inference_1 = TE::signed_word(Some(64));
+        let inference_2 = TE::signed_word(Some(128));
+        let inferences = vec![inference_1, inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that they combine properly, and produce the same error no matter the
+        // order
+        for permutation in permutations {
+            permutation.into_iter().for_each(|i| state.infer(v_1_ty, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(v_1_ty, state.result());
+
+            assert!(result.is_some());
+            assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+        }
+    }
+
+    #[test]
+    fn can_infer_unsigned_word_with_dynamic_array() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let element = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let element_tv = state.register(element);
+
+        // Set up some inferences
+        let inference_1 = TE::unsigned_word(Some(64));
+        let inference_2 = TE::DynamicArray {
+            element: element_tv,
+        };
+        let inferences = vec![inference_1, inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that they combine properly, and produce the same result no matter the
+        // order
+        for permutation in permutations {
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            assert!(result.is_some());
+            assert_eq!(
+                result.unwrap(),
+                TE::DynamicArray {
+                    element: element_tv,
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn conflicts_for_signed_word_with_dynamic_array() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let element = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let element_tv = state.register(element);
+
+        // Set up some inferences
+        let inference_1 = TE::signed_word(Some(64));
+        let inference_2 = TE::DynamicArray {
+            element: element_tv,
+        };
+        let inferences = vec![inference_1, inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that they combine properly, and produce the same result no matter the
+        // order
+        for permutation in permutations {
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            assert!(result.is_some());
+            assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+        }
+    }
+
+    #[test]
+    fn can_infer_dynamic_arrays_with_compatible_element_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let elem_1 = SV::new_value(0, Provenance::Synthetic);
+        let elem_2 = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let elem_1_tv = state.register(elem_1);
+        let elem_2_tv = state.register(elem_2);
+
+        // Create some inferences and register them
+        let array_inference_1 = TE::DynamicArray { element: elem_1_tv };
+        let array_inference_2 = TE::DynamicArray { element: elem_2_tv };
+        let elem_inference_1 = TE::default_word();
+        let elem_inference_2 = TE::signed_word(Some(64));
+        state.infer(elem_1_tv, elem_inference_1);
+        state.infer(elem_2_tv, elem_inference_2);
+        let inferences = vec![array_inference_1, array_inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that we get the same result, and that they combine properly
+        for permutation in permutations {
+            // Register the array inferences in the state
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            // Check the result is right
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            match result.unwrap() {
+                TE::DynamicArray { element } => {
+                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                }
+                _ => panic!("Bad payload in result"),
+            }
+        }
+    }
+
+    #[test]
+    fn conflicts_for_dynamic_arrays_with_incompatible_element_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let elem_1 = SV::new_value(0, Provenance::Synthetic);
+        let elem_2 = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let elem_1_tv = state.register(elem_1);
+        let elem_2_tv = state.register(elem_2);
+
+        // Create some inferences and register them
+        let array_inference_1 = TE::DynamicArray { element: elem_1_tv };
+        let array_inference_2 = TE::DynamicArray { element: elem_2_tv };
+        let elem_inference_1 = TE::unsigned_word(None);
+        let elem_inference_2 = TE::signed_word(Some(64));
+        state.infer(elem_1_tv, elem_inference_1);
+        state.infer(elem_2_tv, elem_inference_2);
+        let inferences = vec![array_inference_1, array_inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that we get the same result, and that they combine properly
+        for permutation in permutations {
+            // Register the array inferences in the state
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            // Check the array is right
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            match result.unwrap() {
+                TE::DynamicArray { element } => {
+                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                }
+                _ => panic!("Bad payload in result"),
+            }
+
+            // But its element type should be a conflict
+            let result = util::get_inference(elem_1_tv, state.result());
+            assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+        }
+    }
+
+    #[test]
+    fn can_infer_fixed_arrays_with_compatible_element_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let elem_1 = SV::new_value(0, Provenance::Synthetic);
+        let elem_2 = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let elem_1_tv = state.register(elem_1);
+        let elem_2_tv = state.register(elem_2);
+        let input_len = U256::from(7u64);
+
+        // Create some inferences and register them
+        let array_inference_1 = TE::FixedArray {
+            element: elem_1_tv,
+            length:  input_len,
+        };
+        let array_inference_2 = TE::FixedArray {
+            element: elem_2_tv,
+            length:  input_len,
+        };
+        let elem_inference_1 = TE::default_word();
+        let elem_inference_2 = TE::signed_word(Some(64));
+        state.infer(elem_1_tv, elem_inference_1);
+        state.infer(elem_2_tv, elem_inference_2);
+        let inferences = vec![array_inference_1, array_inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that we get the same result, and that they combine properly
+        for permutation in permutations {
+            // Register the array inferences in the state
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            // Check the result is right
+            match result.unwrap() {
+                TE::FixedArray { element, length } if length == input_len => {
+                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                }
+                _ => panic!("Bad payload in result"),
+            }
+        }
+    }
+
+    #[test]
+    fn conflicts_for_fixed_arrays_with_incompatible_element_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let elem_1 = SV::new_value(0, Provenance::Synthetic);
+        let elem_2 = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let elem_1_tv = state.register(elem_1);
+        let elem_2_tv = state.register(elem_2);
+        let input_len = U256::from(7u64);
+
+        // Create some inferences and register them
+        let array_inference_1 = TE::FixedArray {
+            element: elem_1_tv,
+            length:  input_len,
+        };
+        let array_inference_2 = TE::FixedArray {
+            element: elem_2_tv,
+            length:  input_len,
+        };
+        let elem_inference_1 = TE::unsigned_word(None);
+        let elem_inference_2 = TE::signed_word(Some(64));
+        state.infer(elem_1_tv, elem_inference_1);
+        state.infer(elem_2_tv, elem_inference_2);
+        let inferences = vec![array_inference_1, array_inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that we get the same result, and that they combine properly
+        for permutation in permutations {
+            // Register the array inferences in the state
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+
+            // Check the result is right
+            match result.unwrap() {
+                TE::FixedArray { element, length } if length == input_len => {
+                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                }
+                _ => panic!("Bad payload in result"),
+            }
+
+            let result = util::get_inference(elem_1_tv, state.result());
+            assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+        }
+    }
+
+    #[test]
+    fn conflicts_for_fixed_arrays_with_incompatible_lengths() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let array = SV::new_value(0, Provenance::Synthetic);
+        let elem_1 = SV::new_value(0, Provenance::Synthetic);
+        let elem_2 = SV::new_value(0, Provenance::Synthetic);
+        let array_tv = state.register(array);
+        let elem_1_tv = state.register(elem_1);
+        let elem_2_tv = state.register(elem_2);
+
+        // Create some inferences and register them
+        let array_inference_1 = TE::FixedArray {
+            element: elem_1_tv,
+            length:  U256::from(7u32),
+        };
+        let array_inference_2 = TE::FixedArray {
+            element: elem_2_tv,
+            length:  U256::from(8u32),
+        };
+        let elem_inference_1 = TE::default_word();
+        let elem_inference_2 = TE::signed_word(Some(64));
+        state.infer(elem_1_tv, elem_inference_1);
+        state.infer(elem_2_tv, elem_inference_2);
+        let inferences = vec![array_inference_1, array_inference_2];
+        let permutations: Vec<Vec<_>> =
+            inferences.iter().permutations(inferences.len()).unique().collect();
+
+        // Check that we get the same result, and that they combine properly
+        for permutation in permutations {
+            // Register the array inferences in the state
+            permutation.into_iter().for_each(|i| state.infer(array_tv, i.clone()));
+
+            unify(&mut state);
+            let result = util::get_inference(array_tv, state.result());
+            assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+        }
+    }
+
+    #[test]
+    fn can_infer_mappings_with_compatible_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let mapping = SV::new_value(0, Provenance::Synthetic);
+        let key_1 = SV::new_value(0, Provenance::Synthetic);
+        let value_1 = SV::new_value(0, Provenance::Synthetic);
+        let key_2 = SV::new_value(0, Provenance::Synthetic);
+        let value_2 = SV::new_value(0, Provenance::Synthetic);
+        let mapping_tv = state.register(mapping);
+        let key_1_tv = state.register(key_1);
+        let value_1_tv = state.register(value_1);
+        let key_2_tv = state.register(key_2);
+        let value_2_tv = state.register(value_2);
+
+        // Create and register inferences
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_1_tv,
+                value: value_1_tv,
+            },
+        );
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_2_tv,
+                value: value_2_tv,
+            },
+        );
+        state.infer(key_1_tv, TE::unsigned_word(None));
+        state.infer(key_2_tv, TE::address());
+        state.infer(value_1_tv, TE::signed_word(Some(32)));
+
+        // Check that we get a sane result out
+        unify(&mut state);
+        let result = util::get_inference(mapping_tv, state.result());
+        match result.unwrap() {
+            TE::Mapping { key, value } => {
+                assert!(vec![key_1_tv, key_2_tv].contains(&key));
+                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+            }
+            _ => panic!("Invalid payload"),
+        }
+    }
+
+    #[test]
+    fn errors_for_mappings_with_incompatible_key_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let mapping = SV::new_value(0, Provenance::Synthetic);
+        let key_1 = SV::new_value(0, Provenance::Synthetic);
+        let value_1 = SV::new_value(0, Provenance::Synthetic);
+        let key_2 = SV::new_value(0, Provenance::Synthetic);
+        let value_2 = SV::new_value(0, Provenance::Synthetic);
+        let mapping_tv = state.register(mapping);
+        let key_1_tv = state.register(key_1);
+        let value_1_tv = state.register(value_1);
+        let key_2_tv = state.register(key_2);
+        let value_2_tv = state.register(value_2);
+
+        // Create and register inferences
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_1_tv,
+                value: value_1_tv,
+            },
+        );
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_2_tv,
+                value: value_2_tv,
+            },
+        );
+        state.infer(key_1_tv, TE::signed_word(None));
+        state.infer(key_2_tv, TE::address());
+        state.infer(value_1_tv, TE::signed_word(Some(32)));
+
+        // Check that we get a sane result out
+        unify(&mut state);
+        let result = util::get_inference(mapping_tv, state.result());
+        match result.unwrap() {
+            TE::Mapping { key, value } => {
+                assert!(vec![key_1_tv, key_2_tv].contains(&key));
+                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+            }
+            _ => panic!("Invalid payload"),
+        }
+
+        let result = util::get_inference(key_1_tv, state.result());
+        assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+    }
+
+    #[test]
+    fn errors_for_mappings_with_incompatible_value_types() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let mapping = SV::new_value(0, Provenance::Synthetic);
+        let key_1 = SV::new_value(0, Provenance::Synthetic);
+        let value_1 = SV::new_value(0, Provenance::Synthetic);
+        let key_2 = SV::new_value(0, Provenance::Synthetic);
+        let value_2 = SV::new_value(0, Provenance::Synthetic);
+        let mapping_tv = state.register(mapping);
+        let key_1_tv = state.register(key_1);
+        let value_1_tv = state.register(value_1);
+        let key_2_tv = state.register(key_2);
+        let value_2_tv = state.register(value_2);
+
+        // Create and register inferences
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_1_tv,
+                value: value_1_tv,
+            },
+        );
+        state.infer(
+            mapping_tv,
+            TE::Mapping {
+                key:   key_2_tv,
+                value: value_2_tv,
+            },
+        );
+        state.infer(key_1_tv, TE::signed_word(None));
+        state.infer(value_1_tv, TE::signed_word(Some(32)));
+        state.infer(value_2_tv, TE::address());
+
+        // Check that we get a sane result out
+        unify(&mut state);
+        let result = util::get_inference(mapping_tv, state.result());
+        match result.unwrap() {
+            TE::Mapping { key, value } => {
+                assert!(vec![key_1_tv, key_2_tv].contains(&key));
+                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+            }
+            _ => panic!("Invalid payload"),
+        }
+
+        let result = util::get_inference(value_1_tv, state.result());
+        assert!(matches!(result.unwrap(), TE::Conflict { .. }));
+    }
+
+    #[test]
+    fn can_infer_any_when_alone() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let value_tv = state.register(value);
+
+        // Set up some inferences
+        state.infer(value_tv, TE::Any);
+        state.infer(value_tv, TE::Any);
+
+        // Check the result makes sense
+        unify(&mut state);
+        let result = util::get_inference(value_tv, state.result());
+        assert_eq!(result.unwrap(), TE::Any);
+    }
+
+    #[test]
+    fn can_infer_other_value_with_any() {
+        // Set up the state
+        let mut state = TypingState::empty();
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let value_tv = state.register(value);
+
+        // Set up some inferences
+        let inference = TE::signed_word(Some(256));
+        state.infer(value_tv, inference.clone());
+        state.infer(value_tv, TE::Any);
+
+        // Check the result makes sense
+        unify(&mut state);
+        let result = util::get_inference(value_tv, state.result());
+        assert_eq!(result.unwrap(), inference);
+    }
+
+    mod util {
+        use crate::unifier::{
+            expression::TypeExpression,
+            state::TypeVariable,
+            unification::UnificationForest,
+        };
+
+        /// Gets the first inference in the forest for `tp`, if it exists,
+        /// returning `None` otherwise.
+        pub fn get_inference(
+            tp: TypeVariable,
+            data: &mut UnificationForest,
+        ) -> Option<TypeExpression> {
+            data.get_data(&tp).and_then(|set| {
+                let items: Vec<_> = set.iter().collect();
+                assert!(items.len() <= 1, "There should only be one inference left");
+                items.first().copied().cloned()
+            })
+        }
+    }
+}

--- a/src/vm/data.rs
+++ b/src/vm/data.rs
@@ -20,6 +20,7 @@ pub struct VisitedOpcodes {
 impl VisitedOpcodes {
     /// Constructs a new visited opcodes container for up to `instructions_len`
     /// opcodes.
+    #[must_use]
     pub fn new(instructions_len: u32, iterations_per_opcode: usize) -> Self {
         let data = HashMap::default();
 
@@ -137,7 +138,7 @@ mod test {
         }
 
         #[test]
-        fn cannot_mark_invalid_instructions_as_visited() -> anyhow::Result<()> {
+        fn cannot_mark_invalid_instructions_as_visited() {
             let mut tracker = VisitedOpcodes::new(20, 1);
             let mark = tracker
                 .mark_visited(1000)
@@ -150,12 +151,10 @@ mod test {
                     available: 20,
                 }
             );
-
-            Ok(())
         }
 
         #[test]
-        fn cannot_unmark_invalid_instructions_as_visited() -> anyhow::Result<()> {
+        fn cannot_unmark_invalid_instructions_as_visited() {
             let mut tracker = VisitedOpcodes::new(20, 1);
             let mark = tracker
                 .unmark_visited(1000)
@@ -168,8 +167,6 @@ mod test {
                     available: 20,
                 }
             );
-
-            Ok(())
         }
     }
 }

--- a/src/vm/state/memory.rs
+++ b/src/vm/state/memory.rs
@@ -36,6 +36,7 @@ pub struct Memory {
 
 impl Memory {
     /// Constructs a new memory container that currently stores no data.
+    #[must_use]
     pub fn new() -> Self {
         let constant_offsets = HashMap::default();
         let symbolic_offsets = HashMap::default();
@@ -57,7 +58,7 @@ impl Memory {
     /// account for sub-word writes by dissecting the arguments to this
     /// function.
     pub fn store(&mut self, offset: BoxedVal, value: BoxedVal) {
-        self.store_with_size(offset, value, MemStoreSize::Word)
+        self.store_with_size(offset, value, MemStoreSize::Word);
     }
 
     /// Stores the provided `value` (of size 8-bits) at the provided `offset`
@@ -68,11 +69,11 @@ impl Memory {
     /// # Note
     ///
     /// Be careful with overlapping stores, as the storage is not able to track
-    /// these. Implementation of the `MLOAD` and MSTORE*` opcodes may want to
+    /// these. Implementation of the `MLOAD` and `MSTORE*` opcodes may want to
     /// account for sub-word writes by dissecting the arguments to this
     /// function.
     pub fn store_8(&mut self, offset: BoxedVal, value: BoxedVal) {
-        self.store_with_size(offset, value, MemStoreSize::Byte)
+        self.store_with_size(offset, value, MemStoreSize::Byte);
     }
 
     /// Performs an internal store of `value` at `offset` using the specified
@@ -81,7 +82,7 @@ impl Memory {
     /// # Note
     ///
     /// Be careful with overlapping stores, as the storage is not able to track
-    /// these. Implementation of the `MLOAD` and MSTORE*` opcodes may want to
+    /// these. Implementation of the `MLOAD` and `MSTORE*` opcodes may want to
     /// account for sub-word writes by dissecting the arguments to this
     /// function.
     #[allow(clippy::boxed_local)] // We use boxes everywhere for API simplicity.
@@ -108,6 +109,7 @@ impl Memory {
     ///
     /// This is a best-effort analysis as we cannot guarantee knowing if there
     /// have been overwrites between adjacent slots.
+    #[must_use]
     pub fn load(&mut self, offset: &BoxedVal) -> BoxedVal {
         let offset = offset.clone().constant_fold();
         match offset.data {
@@ -131,6 +133,7 @@ impl Memory {
     /// - Where `offset` is symbolic, it will return only the word at `offset`.
     ///
     /// Note that we hope to improve this behaviour in the future.
+    #[must_use]
     pub fn load_slice(
         &mut self,
         offset: &BoxedVal,
@@ -139,7 +142,7 @@ impl Memory {
     ) -> BoxedVal {
         let offset = offset.clone().constant_fold();
         match &offset.data {
-            SymbolicValueData::KnownData { value } => match self.decompose_size(size) {
+            SymbolicValueData::KnownData { value } => match Self::decompose_size(size) {
                 Some(size) => {
                     let offset: usize = value.into();
                     let mut values = vec![];
@@ -174,7 +177,8 @@ impl Memory {
 
     /// Determines whether the size is concrete, returning the concrete read
     /// size if so, and [`None`] otherwise.
-    fn decompose_size(&self, size: &BoxedVal) -> Option<usize> {
+    #[must_use]
+    fn decompose_size(size: &BoxedVal) -> Option<usize> {
         match &size.data {
             SymbolicValueData::KnownData { value } => Some(value.into()),
             _ => None,
@@ -184,6 +188,7 @@ impl Memory {
     /// Gets the item at the provided `key` from the provided `map`,
     /// initializing the read memory to all zeroes if it has not previously been
     /// written.
+    #[must_use]
     fn get_or_initialize<'a, K>(map: &'a mut HashMap<K, Vec<MemStore>>, key: &'a K) -> &'a BoxedVal
     where
         K: Clone + Eq + Hash + PartialEq,
@@ -213,6 +218,7 @@ impl Memory {
     ///
     /// Returns [`Some`] for offsets that have seen at least one write, and
     /// otherwise returns [`None`].
+    #[must_use]
     pub fn generations(&self, offset: &BoxedVal) -> Option<Vec<&BoxedVal>> {
         self.symbolic_offsets
             .get(offset)
@@ -223,6 +229,7 @@ impl Memory {
     /// location.
     ///
     /// This functionality exists primarily for introspection.
+    #[must_use]
     pub fn query_store_size(&self, offset: &BoxedVal) -> Option<MemStoreSize> {
         self.symbolic_offsets
             .get(offset)
@@ -234,22 +241,26 @@ impl Memory {
     ///
     /// This has no equivalent operation on the EVM and is primarily useful for
     /// introspection.
+    #[must_use]
     pub fn entry_count(&self) -> usize {
         self.symbolic_offsets.len() + self.constant_offsets.len()
     }
 
     /// Checks if the memory has ever been written to.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.entry_count() == 0
     }
 
     /// Gets the offsets in memory that have been written to.
+    #[must_use]
     pub fn offsets(&self) -> Vec<&BoxedVal> {
         self.symbolic_offsets.keys().collect()
     }
 
     /// Gets all of the values that are registered in the virtual machine memory
     /// at the time of calling.
+    #[must_use]
     pub fn all_values(&self) -> Vec<BoxedVal> {
         let mut values = Vec::new();
         self.constant_offsets
@@ -287,6 +298,7 @@ pub enum MemStoreSize {
 
 impl MemStoreSize {
     /// Gets the number of bits that were stored into memory for a given write.
+    #[must_use]
     pub fn bits_count(&self) -> usize {
         match self {
             MemStoreSize::Byte => 8,
@@ -303,6 +315,7 @@ mod test {
     };
 
     /// Creates a new synthetic value for testing purposes.
+    #[allow(clippy::unnecessary_box_returns)] // We use boxes everywhere during execution
     fn new_synthetic_value(instruction_pointer: u32) -> BoxedVal {
         SymbolicValue::new_value(instruction_pointer, Provenance::Synthetic)
     }
@@ -325,7 +338,7 @@ mod test {
         assert_eq!(
             memory.query_store_size(&offset).unwrap(),
             MemStoreSize::Word
-        )
+        );
     }
 
     #[test]
@@ -356,7 +369,7 @@ mod test {
         assert_eq!(
             memory.query_store_size(&offset).unwrap(),
             MemStoreSize::Byte
-        )
+        );
     }
 
     #[test]
@@ -428,7 +441,7 @@ mod test {
         let result = memory.load_slice(&offset_1, &bytes_64, 5);
         match &result.data {
             SymbolicValueData::Concat { values } => {
-                assert_eq!(values, &vec![value_1, value_2])
+                assert_eq!(values, &vec![value_1, value_2]);
             }
             _ => panic!("Invalid payload"),
         }
@@ -468,6 +481,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::similar_names)] // The names are actually perfectly descriptive
     fn can_store_and_retrieve_more_complex_values() {
         let mut memory = Memory::new();
         let left = new_synthetic_value(0);

--- a/src/vm/state/mod.rs
+++ b/src/vm/state/mod.rs
@@ -52,6 +52,7 @@ pub struct VMState {
 impl VMState {
     /// Constructs a new virtual machine state originating at the provided
     /// `fork_point`, with all memory locations set to their default values.
+    #[must_use]
     pub fn new(fork_point: u32, instructions_len: u32, iterations_per_opcode: usize) -> Self {
         let stack = Stack::new();
         let memory = Memory::new();
@@ -73,48 +74,57 @@ impl VMState {
 
     /// Creates a new virtual machine state originating at the start of
     /// execution, with all memory locations set to their default values.
+    #[must_use]
     pub fn new_at_start(instructions_len: u32, iterations_per_opcode: usize) -> Self {
         Self::new(0, instructions_len, iterations_per_opcode)
     }
 
     /// Gets the stack associated with this virtual machine state.
+    #[must_use]
     pub fn stack(&self) -> &Stack {
         &self.stack
     }
 
     /// Gets the stack associated with this virtual machine state.
+    #[must_use]
     pub fn stack_mut(&mut self) -> &mut Stack {
         &mut self.stack
     }
 
     /// Gets the memory associated with this virtual machine state.
+    #[must_use]
     pub fn memory(&self) -> &Memory {
         &self.memory
     }
 
     /// Gets the memory associated with this virtual machine state.
+    #[must_use]
     pub fn memory_mut(&mut self) -> &mut Memory {
         &mut self.memory
     }
 
     /// Gets the storage associated with this virtual machine state.
+    #[must_use]
     pub fn storage(&self) -> &Storage {
         &self.storage
     }
 
     /// Gets the storage associated with this virtual machine state.
+    #[must_use]
     pub fn storage_mut(&mut self) -> &mut Storage {
         &mut self.storage
     }
 
     /// Gets the structure that tracks whether a given opcode has been visited
     /// by the current thread of execution.
+    #[must_use]
     pub fn visited_instructions(&self) -> &VisitedOpcodes {
         &self.visited_instructions
     }
 
     /// Gets the structure that tracks whether a given opcode has been visited
     /// by the current thread of execution.
+    #[must_use]
     pub fn visited_instructions_mut(&mut self) -> &mut VisitedOpcodes {
         &mut self.visited_instructions
     }
@@ -128,6 +138,7 @@ impl VMState {
 
     /// Gets the values that have been recorded to be available for analysis
     /// though not stored in the VM's working memories.
+    #[must_use]
     pub fn recorded_values(&self) -> &[BoxedVal] {
         self.recorded_values.as_slice()
     }
@@ -141,12 +152,14 @@ impl VMState {
 
     /// Gets the values that have been recorded to be available for analysis
     /// though not stored in the VM's working memories.
+    #[must_use]
     pub fn logged_values(&self) -> &[BoxedVal] {
         self.logged_values.as_slice()
     }
 
     /// Gets the point in the instruction stream, specifically the value of the
     /// instruction pointer, at which this VM state was forked.
+    #[must_use]
     pub fn fork_point(&self) -> u32 {
         self.fork_point
     }
@@ -156,6 +169,7 @@ impl VMState {
     /// it was forked from.
     ///
     /// This is used for exploring all branches of the bytecode.
+    #[must_use]
     pub fn fork(&self, fork_point: u32) -> Self {
         let mut fork = self.clone();
         fork.fork_point = fork_point;
@@ -165,6 +179,7 @@ impl VMState {
 
     /// Gets all of the values that are registered in the virtual machine state
     /// at the time of calling.
+    #[must_use]
     pub fn all_values(&self) -> Vec<BoxedVal> {
         let mut values = Vec::new();
         values.extend(self.stack.all_values());

--- a/src/vm/thread.rs
+++ b/src/vm/thread.rs
@@ -23,6 +23,7 @@ pub struct VMThread {
 impl VMThread {
     /// Constructs a new virtual machine thread with `state` as the initial
     /// state at `thread.instruction_pointer()`.
+    #[must_use]
     pub fn new(state: VMState, thread: ExecutionThread) -> Self {
         let gas_usage = 0;
         Self {
@@ -33,23 +34,27 @@ impl VMThread {
     }
 
     /// Gets the current virtual machine state for this virtual machine thread.
+    #[must_use]
     pub fn state(&self) -> &VMState {
         &self.state
     }
 
     /// Gets the current virtual machine state for this virtual machine thread.
+    #[must_use]
     pub fn state_mut(&mut self) -> &mut VMState {
         &mut self.state
     }
 
     /// Gets the instruction stream and current execution position associated
     /// with this virtual machine thread.
+    #[must_use]
     pub fn instructions(&self) -> &ExecutionThread {
         &self.thread
     }
 
     /// Gets the instruction stream and current execution position associated
     /// with this virtual machine thread.
+    #[must_use]
     pub fn instructions_mut(&mut self) -> &mut ExecutionThread {
         &mut self.thread
     }
@@ -60,6 +65,7 @@ impl VMThread {
     ///
     /// This method performs no validation as to whether the fork point is a
     /// valid fork point. This is up to the VM itself.
+    #[must_use]
     pub fn fork(&self, target: u32) -> Self {
         let instruction_pointer = self.thread.instruction_pointer();
         let state = self.state.fork(instruction_pointer);
@@ -76,10 +82,11 @@ impl VMThread {
 
     /// Adds the provided `gas` to the gas usage of this thread.
     pub fn consume_gas(&mut self, gas: usize) {
-        self.gas_usage += gas
+        self.gas_usage += gas;
     }
 
     /// Gets the gas usage of this thread.
+    #[must_use]
     pub fn gas_usage(&self) -> usize {
         self.gas_usage
     }
@@ -104,7 +111,7 @@ mod test {
             vec![0x00u8, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06].as_slice(),
         )?;
         let state = VMState::new_at_start(
-            instruction_stream.len() as u32,
+            u32::try_from(instruction_stream.len()).unwrap(),
             DEFAULT_ITERATIONS_PER_OPCODE,
         );
         let execution_thread = instruction_stream.new_thread(0)?;

--- a/src/vm/value/known.rs
+++ b/src/vm/value/known.rs
@@ -18,11 +18,13 @@ pub struct KnownWord {
 impl KnownWord {
     /// Creates a known value representing zero as a 256-bit wide unsigned
     /// integer.
+    #[must_use]
     pub fn zero() -> Self {
         Self::from(vec![0])
     }
 
     /// Gets the value of the known word.
+    #[must_use]
     pub fn value(&self) -> U256 {
         self.value
     }

--- a/src/vm/value/mod.rs
+++ b/src/vm/value/mod.rs
@@ -46,6 +46,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
+    #[must_use]
     pub fn new(
         instruction_pointer: u32,
         data: SymbolicValueData,
@@ -65,6 +66,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
+    #[must_use]
     pub fn new_from_execution(instruction_pointer: u32, data: SymbolicValueData) -> Box<Self> {
         Self::new(instruction_pointer, data, Provenance::Execution)
     }
@@ -76,6 +78,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
+    #[must_use]
     pub fn new_synthetic(instruction_pointer: u32, data: SymbolicValueData) -> Box<Self> {
         Self::new(instruction_pointer, data, Provenance::Synthetic)
     }
@@ -85,6 +88,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
+    #[must_use]
     pub fn new_value(instruction_pointer: u32, provenance: Provenance) -> Box<Self> {
         Self::new(
             instruction_pointer,
@@ -99,6 +103,7 @@ impl SymbolicValue {
     ///
     /// It returns [`Box<Self>`] as in the vast majority of cases this type is
     /// used in a recursive data type and hence indirection is needed.
+    #[must_use]
     pub fn new_known_value(
         instruction_pointer: u32,
         value_data: KnownWord,
@@ -113,6 +118,7 @@ impl SymbolicValue {
 
     /// Compares two symbolic values for strict equality, _including_ the value
     /// of the `instruction_pointer`.
+    #[must_use]
     pub fn strict_eq(&self, other: &Self) -> bool {
         self.instruction_pointer == other.instruction_pointer && self == other
     }
@@ -127,6 +133,7 @@ impl SymbolicValue {
     ///
     /// This algorithm is recursive. If it turns out to be a problem in practice
     /// it can be re-written.
+    #[must_use]
     pub fn constant_fold(self) -> BoxedVal {
         let data = self.data.constant_fold();
         let instruction_pointer = self.instruction_pointer;
@@ -140,11 +147,13 @@ impl SymbolicValue {
     }
 
     /// Checks if the payload is known data.
+    #[must_use]
     pub fn is_known_data(&self) -> bool {
         matches!(self.data, SymbolicValueData::KnownData { .. })
     }
 
     /// Converts the payload into a VM word if possible.
+    #[must_use]
     pub fn as_word(&self) -> Option<U256> {
         match &self.data {
             SymbolicValueData::KnownData { value } => Some(value.value()),
@@ -154,6 +163,7 @@ impl SymbolicValue {
 
     /// Transforms the payload data of the symbolic value by processing
     /// `self.data` with the `transform`.
+    #[must_use]
     pub fn transform_data(
         self,
         transform: impl Fn(&SymbolicValueData) -> Option<SymbolicValueData> + Copy,
@@ -166,6 +176,7 @@ impl SymbolicValue {
     }
 
     /// Gets all of the child nodes of this node.
+    #[must_use]
     pub fn children(&self) -> Vec<&BoxedVal> {
         self.data.children()
     }
@@ -426,11 +437,13 @@ pub enum SymbolicValueData {
 
 impl SymbolicValueData {
     /// Constructs a new [`Self::KnownData`] containing the data `value`.
+    #[must_use]
     pub fn new_known(value: KnownWord) -> Self {
         SymbolicValueData::KnownData { value }
     }
 
     /// Constructs a new [`Self::KnownData`] wrapping `value`.
+    #[must_use]
     fn known_from(value: U256) -> Self {
         Self::KnownData {
             value: value.into(),
@@ -439,12 +452,14 @@ impl SymbolicValueData {
 
     /// Constructs a new [`Self::Value`] about which only its existence and
     /// identity are known.
+    #[must_use]
     pub fn new_value() -> Self {
         let id = Uuid::new_v4();
         SymbolicValueData::Value { id }
     }
 
     /// Constructs a new [`Self::CallData`] instance with identity.
+    #[must_use]
     pub fn call_data(offset: BoxedVal, size: BoxedVal) -> Self {
         let id = Uuid::new_v4();
         Self::CallData { id, offset, size }
@@ -461,6 +476,8 @@ impl SymbolicValueData {
     ///
     /// This algorithm is recursive. If it turns out to be a problem in practice
     /// it can be re-written.
+    #[allow(clippy::match_same_arms, clippy::too_many_lines)]
+    #[must_use]
     pub fn transform(self, transform: impl Fn(&Self) -> Option<Self> + Copy) -> Self {
         match transform(&self) {
             Some(data) => data,
@@ -697,8 +714,11 @@ impl SymbolicValueData {
     ///
     /// This algorithm is recursive. If it turns out to be a problem in practice
     /// it can be re-written.
+    #[allow(clippy::match_same_arms, clippy::too_many_lines)]
+    #[must_use]
     pub fn constant_fold(self) -> Self {
         // The inner definition that actually implements the constant folding operation.
+        #[allow(clippy::too_many_lines)]
         fn constant_folder(data: &SVD) -> Option<SVD> {
             match data.clone() {
                 SVD::Add { left, right } => {
@@ -891,6 +911,8 @@ impl SymbolicValueData {
     }
 
     /// Gets the children of the provided node.
+    #[allow(clippy::match_same_arms)]
+    #[must_use]
     pub fn children(&self) -> Vec<&BoxedVal> {
         match self {
             Self::Value { .. } => vec![],
@@ -1199,7 +1221,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(8), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1217,7 +1239,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(7), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1235,7 +1257,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(6), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1253,7 +1275,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(7), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1271,7 +1293,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(7), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1289,7 +1311,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(1), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1307,7 +1329,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(1), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1325,7 +1347,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(49), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1343,7 +1365,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(true), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1361,7 +1383,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(false), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1379,7 +1401,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(true), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1397,7 +1419,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(false), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1415,7 +1437,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(false), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1432,7 +1454,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(false), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1452,7 +1474,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(0b0100), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1472,7 +1494,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(0b1111), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1492,7 +1514,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(0b1011), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1509,7 +1531,7 @@ mod test {
                 KnownWord::from(!U256::from(1u8)),
                 Provenance::Synthetic
             )
-        )
+        );
     }
 
     #[test]
@@ -1527,8 +1549,8 @@ mod test {
 
         assert_eq!(
             folded,
-            SymbolicValue::new_known_value(2, KnownWord::from(0b111000), Provenance::Synthetic)
-        )
+            SymbolicValue::new_known_value(2, KnownWord::from(0b11_1000), Provenance::Synthetic)
+        );
     }
 
     #[test]
@@ -1547,7 +1569,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(0b11), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1566,7 +1588,7 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(0b11), Provenance::Synthetic)
-        )
+        );
     }
 
     #[test]
@@ -1599,6 +1621,6 @@ mod test {
         assert_eq!(
             folded,
             SymbolicValue::new_known_value(2, KnownWord::from(16), Provenance::Synthetic)
-        )
+        );
     }
 }

--- a/tests/manual_inspection.rs
+++ b/tests/manual_inspection.rs
@@ -50,7 +50,7 @@ fn inspect_contract_data() -> anyhow::Result<()> {
     }
 
     // Prepare the unifier
-    let unifier_read = executed.prepare_unifier()?;
+    let unifier_read = executed.prepare_unifier();
 
     // Perform unification
     let unification_complete = unifier_read.unify()?;

--- a/tests/simple_contract.rs
+++ b/tests/simple_contract.rs
@@ -26,8 +26,15 @@ fn analyses_simple_contract() -> anyhow::Result<()> {
             val_tp: Box::new(AbiType::Any),
         }),
     };
-    let expected_mapping_slot = StorageSlot::new(0, expected_mapping);
+    let expected_mapping_slot = StorageSlot::new(0, expected_mapping, false);
     assert!(layout.slots().contains(&expected_mapping_slot));
+
+    // Check that we see the `any[]`
+    let expected_dyn_array = AbiType::DynArray {
+        tp: Box::new(AbiType::Any),
+    };
+    let expected_array_slot = StorageSlot::new(1, expected_dyn_array, false);
+    assert!(layout.slots().contains(&expected_array_slot));
 
     Ok(())
 }


### PR DESCRIPTION
# Summary

This approach performs all resolution in the space of the typing inferences, using rules to collapse multiple inferences into one where possible. It handles the conversion to the `AbiType` separately.

Closes #8 
Closes #12 

# Details

Please carefully check that the rules for combining things make sense.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
