### PR TITLE
Add some basic inference rules

### DIFF
--- a/src/unifier/expression.rs
+++ b/src/unifier/expression.rs
@@ -125,6 +125,14 @@ impl TypeExpression {
         Self::word(width, signed, WordUse::Function)
     }
 
+    /// Constructs a word that is actually used as one of the fixed-size byte
+    /// arrays.
+    #[must_use]
+    pub fn bytes(width: Option<usize>) -> Self {
+        let signed = Some(false);
+        Self::word(width, signed, WordUse::Bytes)
+    }
+
     /// Constructs an equality wrapping the provided type variable `id`.
     #[must_use]
     pub fn eq(id: TypeVariable) -> Self {
@@ -192,6 +200,9 @@ pub enum WordUse {
     /// The word has been used as a function (an address followed by a
     /// selector).
     Function,
+
+    /// The word is used as bytes directly rather than a standard word.
+    Bytes,
 
     /// Conflicting usages found.
     Conflict { conflicts: Vec<WordUse> },

--- a/src/unifier/inference_rule/arithmetic_operations.rs
+++ b/src/unifier/inference_rule/arithmetic_operations.rs
@@ -1,0 +1,349 @@
+//! This module contains inference rules that deal with basic arithmetic
+//! operations.
+
+use crate::{
+    constant::WORD_SIZE,
+    error::unification::Result,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule marks the operands and result of the arithmetic operations as
+/// being the appropriate type of word.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ArithmeticOperationRule;
+
+impl InferenceRule for ArithmeticOperationRule {
+    fn infer(&self, value: &BoxedVal, state: &mut TypingState) -> Result<()> {
+        match &value.data {
+            SVD::Add { left, right }
+            | SVD::Multiply { left, right }
+            | SVD::Subtract { left, right } => {
+                state.infer_for_many([value, left, right], TE::default_word());
+            }
+            SVD::Divide { dividend, divisor } | SVD::Modulo { dividend, divisor } => {
+                state.infer_for_many([value, dividend, divisor], TE::default_word());
+            }
+            SVD::SignedDivide { dividend, divisor } | SVD::SignedModulo { dividend, divisor } => {
+                state.infer_for_many([value, dividend, divisor], TE::signed_word(None));
+            }
+            SVD::Exp {
+                value: exp_val,
+                exponent,
+            } => {
+                state.infer_for_many([value, exp_val, exponent], TE::default_word());
+            }
+            SVD::SignExtend {
+                value: extend_val,
+                size,
+            } => {
+                state.infer_for(extend_val, TE::signed_word(None));
+                state.infer_for(size, TE::unsigned_word(None));
+
+                // If we can unpick the size itself to a known value, we can get a width
+                let width = if let SVD::KnownData { value } = &size.data {
+                    let width: usize = value.into();
+
+                    if width <= WORD_SIZE {
+                        Some(width)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                state.infer_for(value, TE::signed_word(width));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{arithmetic_operations::ArithmeticOperationRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{known::KnownWord, Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_add() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let add = SV::new(
+            2,
+            SVD::Add {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [left_ty, right_ty, add_ty] = state.register_many([left, right, add.clone()]);
+        ArithmeticOperationRule.infer(&add, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::default_word()));
+        assert!(state.inferences(right_ty).contains(&TE::default_word()));
+        assert!(state.inferences(add_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_multiply() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let mul = SV::new(
+            2,
+            SVD::Add {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [left_ty, right_ty, mul_ty] = state.register_many([left, right, mul.clone()]);
+        ArithmeticOperationRule.infer(&mul, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::default_word()));
+        assert!(state.inferences(right_ty).contains(&TE::default_word()));
+        assert!(state.inferences(mul_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_subtract() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let sub = SV::new(
+            2,
+            SVD::Add {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [left_ty, right_ty, sub_ty] = state.register_many([left, right, sub.clone()]);
+        ArithmeticOperationRule.infer(&sub, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::default_word()));
+        assert!(state.inferences(right_ty).contains(&TE::default_word()));
+        assert!(state.inferences(sub_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_divide() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = SV::new_value(0, Provenance::Synthetic);
+        let divisor = SV::new_value(1, Provenance::Synthetic);
+        let div = SV::new(
+            2,
+            SVD::Divide {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [dividend_ty, divisor_ty, div_ty] =
+            state.register_many([dividend, divisor, div.clone()]);
+        ArithmeticOperationRule.infer(&div, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::default_word()));
+        assert!(state.inferences(divisor_ty).contains(&TE::default_word()));
+        assert!(state.inferences(div_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_signed_divide() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = SV::new_value(0, Provenance::Synthetic);
+        let divisor = SV::new_value(1, Provenance::Synthetic);
+        let div = SV::new(
+            2,
+            SVD::SignedDivide {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [dividend_ty, divisor_ty, div_ty] =
+            state.register_many([dividend, divisor, div.clone()]);
+        ArithmeticOperationRule.infer(&div, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_modulo() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = SV::new_value(0, Provenance::Synthetic);
+        let divisor = SV::new_value(1, Provenance::Synthetic);
+        let modulo = SV::new(
+            2,
+            SVD::Modulo {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [dividend_ty, divisor_ty, div_ty] =
+            state.register_many([dividend, divisor, modulo.clone()]);
+        ArithmeticOperationRule.infer(&modulo, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::default_word()));
+        assert!(state.inferences(divisor_ty).contains(&TE::default_word()));
+        assert!(state.inferences(div_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_signed_modulo() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = SV::new_value(0, Provenance::Synthetic);
+        let divisor = SV::new_value(1, Provenance::Synthetic);
+        let modulo = SV::new(
+            2,
+            SVD::SignedModulo {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [dividend_ty, divisor_ty, div_ty] =
+            state.register_many([dividend, divisor, modulo.clone()]);
+        ArithmeticOperationRule.infer(&modulo, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_exp() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let exponent = SV::new_value(1, Provenance::Synthetic);
+        let exp = SV::new(
+            2,
+            SVD::Exp {
+                value:    value.clone(),
+                exponent: exponent.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [value_ty, exponent_ty, exp_ty] = state.register_many([value, exponent, exp.clone()]);
+        ArithmeticOperationRule.infer(&exp, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::default_word()));
+        assert!(state.inferences(exponent_ty).contains(&TE::default_word()));
+        assert!(state.inferences(exp_ty).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sign_extend_with_known_size() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let size = SV::new_known_value(1, KnownWord::from(128), Provenance::Synthetic);
+        let ext = SV::new(
+            2,
+            SVD::SignExtend {
+                value: value.clone(),
+                size:  size.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [value_ty, size_ty, ext_ty] = state.register_many([value, size, ext.clone()]);
+        ArithmeticOperationRule.infer(&ext, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(size_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(ext_ty).contains(&TE::signed_word(Some(128))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sign_extend_with_unknown_size() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let size = SV::new_value(1, Provenance::Synthetic);
+        let ext = SV::new(
+            2,
+            SVD::SignExtend {
+                value: value.clone(),
+                size:  size.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Register them with the state and run inference
+        let mut state = TypingState::empty();
+        let [value_ty, size_ty, ext_ty] = state.register_many([value, size, ext.clone()]);
+        ArithmeticOperationRule.infer(&ext, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(size_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(ext_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/bit_shifts.rs
+++ b/src/unifier/inference_rule/bit_shifts.rs
@@ -1,0 +1,145 @@
+//! This module contains an inference rule for dealing with the bit shift
+//! operations.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This inference rule is able to say that the shift amount is always unsigned,
+/// and depending on the kind of shift we may know that the value being shifted
+/// is signed or not.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BitShiftRule;
+
+impl InferenceRule for BitShiftRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::LeftShift {
+                shift,
+                value: shift_val,
+            }
+            | SVD::RightShift {
+                shift,
+                value: shift_val,
+            } => {
+                // The shift amount is always interpreted as unsigned
+                state.infer_for(shift, TE::unsigned_word(None));
+
+                // We know nothing about the result of a normal bit shift or the value
+                state.infer_for_many([value, shift_val], TE::default_word());
+            }
+            SVD::ArithmeticRightShift {
+                shift,
+                value: shift_val,
+            } => {
+                // The shift amount is always interpreted as unsigned
+                state.infer_for(shift, TE::unsigned_word(None));
+
+                // But here as it is an arithmetic shift, the value being shifted is being
+                // treated as signed, and hence so is the result
+                state.infer_for_many([value, shift_val], TE::signed_word(None));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{bit_shifts::BitShiftRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_left_shift() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let shift_amount = SV::new_value(1, Provenance::Synthetic);
+        let shift = SV::new_synthetic(
+            2,
+            SVD::LeftShift {
+                shift: shift_amount.clone(),
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the inference rule
+        let mut state = TypingState::empty();
+        let [value_tv, shift_amount_tv, shift_tv] =
+            state.register_many([value, shift_amount, shift.clone()]);
+        BitShiftRule.infer(&shift, &mut state)?;
+
+        // Check we get the expected equations
+        assert!(state.inferences(value_tv).contains(&TE::default_word()));
+        assert!(state.inferences(shift_amount_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(shift_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_right_shift() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let shift_amount = SV::new_value(1, Provenance::Synthetic);
+        let shift = SV::new_synthetic(
+            2,
+            SVD::RightShift {
+                shift: shift_amount.clone(),
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the inference rule
+        let mut state = TypingState::empty();
+        let [value_tv, shift_amount_tv, shift_tv] =
+            state.register_many([value, shift_amount, shift.clone()]);
+        BitShiftRule.infer(&shift, &mut state)?;
+
+        // Check we get the expected equations
+        assert!(state.inferences(value_tv).contains(&TE::default_word()));
+        assert!(state.inferences(shift_amount_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(shift_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_arithmetic_right_shift() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let shift_amount = SV::new_value(1, Provenance::Synthetic);
+        let shift = SV::new_synthetic(
+            2,
+            SVD::ArithmeticRightShift {
+                shift: shift_amount.clone(),
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the inference rule
+        let mut state = TypingState::empty();
+        let [value_tv, shift_amount_tv, shift_tv] =
+            state.register_many([value, shift_amount, shift.clone()]);
+        BitShiftRule.infer(&shift, &mut state)?;
+
+        // Check we get the expected equations
+        assert!(state.inferences(value_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(shift_amount_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(shift_tv).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/boolean_operations.rs
+++ b/src/unifier/inference_rule/boolean_operations.rs
@@ -1,0 +1,324 @@
+//! This module defines basic inferences for the set of boolean operations that
+//! can be performed on the EVM.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule is responsible for making inferences based on the presence of
+/// boolean operations.
+///
+/// Unfortunately, many boolean operations do not tell us much as they operate
+/// bitwise, but we can usually say that the operands are some kind of word.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BooleanOpsRule;
+
+impl InferenceRule for BooleanOpsRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            // LT and GT are numeric comparisons, so we know that the operands are numeric, and not
+            // treated as signed
+            SVD::LessThan { left, right } | SVD::GreaterThan { left, right } => {
+                state.infer_for_many([left, right], TE::unsigned_word(None));
+                state.infer_for(value, TE::bool());
+            }
+            // SLT and SGT are numeric and signed, so they are signed numeric
+            SVD::SignedLessThan { left, right } | SVD::SignedGreaterThan { left, right } => {
+                state.infer_for_many([left, right], TE::signed_word(None));
+                state.infer_for(value, TE::bool());
+            }
+            // Equality can operate over arbitrary words, of any width
+            SVD::Equals { left, right } => {
+                state.infer_for_many([left, right], TE::default_word());
+                state.infer_for(value, TE::bool());
+            }
+            // This is a numeric comparison to zero
+            SVD::IsZero { number } => {
+                state.infer_for(number, TE::default_word());
+                state.infer_for(value, TE::bool());
+            }
+            // These operate over arbitrary words as well
+            SVD::And { left, right } | SVD::Or { left, right } | SVD::Xor { left, right } => {
+                state.infer_for_many([left, right], TE::default_word());
+                state.infer_for(value, TE::default_word());
+            }
+            SVD::Not { value: not_val } => {
+                state.infer_for_many([value, not_val], TE::default_word());
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{boolean_operations::BooleanOpsRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_lt() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::LessThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gt() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::GreaterThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_slt() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::SignedLessThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sgt() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::SignedGreaterThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_eq() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::Equals {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::default_word()));
+        assert!(state.inferences(right_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_is_zero() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::IsZero {
+                number: value.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [value_tv, operator_tv] = state.register_many([value, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_and() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::And {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::default_word()));
+        assert!(state.inferences(right_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_or() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::Or {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::default_word()));
+        assert!(state.inferences(right_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_xor() -> anyhow::Result<()> {
+        // Create some values
+        let left = SV::new_value(0, Provenance::Synthetic);
+        let right = SV::new_value(1, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::Xor {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [left_tv, right_tv, operator_tv] = state.register_many([left, right, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::default_word()));
+        assert!(state.inferences(right_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_not() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            2,
+            SVD::Not {
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [value_tv, operator_tv] = state.register_many([value, operator.clone()]);
+        BooleanOpsRule.infer(&operator, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::default_word()));
+        assert!(state.inferences(operator_tv).contains(&TE::default_word()));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/condition.rs
+++ b/src/unifier/inference_rule/condition.rs
@@ -1,0 +1,68 @@
+//! This module contains an inference rule for dealing with values explicitly
+//! used as conditions.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the equation `a = bool` for expressions of the following
+/// form.
+///
+/// ```text
+/// cond(value)
+///   a    b
+/// ```
+///
+/// - `a = bool`
+/// - `b = bool`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ConditionRule;
+
+impl InferenceRule for ConditionRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::Condition { value: cond_val } = &value.data else { return Ok(()) };
+        state.infer_for_many([value, cond_val], TE::bool());
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{condition::ConditionRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_conditions() -> anyhow::Result<()> {
+        // Create the values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let cond = SV::new_synthetic(
+            1,
+            SVD::Condition {
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [value_tv, cond_tv] = state.register_many([value, cond.clone()]);
+        ConditionRule.infer(&cond, &mut state)?;
+
+        // Check we get the equations
+        assert!(state.inferences(value_tv).contains(&TE::bool()));
+        assert!(state.inferences(cond_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/create.rs
+++ b/src/unifier/inference_rule/create.rs
@@ -1,0 +1,114 @@
+//! This module contains inference rules for dealing with the arguments and
+//! return values when creating new contracts.
+
+use crate::{
+    constant::WORD_SIZE,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This inference rule states that the result of calling either `CREATE` or
+/// `CREATE2` is an address, and that the provided `value` upon creation is some
+/// unsigned integer.
+///
+/// We know nothing about the data from this usage site.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CreateContractRule;
+
+impl InferenceRule for CreateContractRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::Create {
+                value: create_val, ..
+            } => {
+                state.infer_for(value, TE::address());
+                state.infer_for(create_val, TE::unsigned_word(None));
+            }
+            SVD::Create2 {
+                value: create_val,
+                salt,
+                ..
+            } => {
+                state.infer_for(value, TE::address());
+                state.infer_for(create_val, TE::unsigned_word(None));
+                state.infer_for(salt, TE::bytes(Some(WORD_SIZE)));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        constant::WORD_SIZE,
+        unifier::{
+            expression::TE,
+            inference_rule::{create::CreateContractRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_create() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let data = SV::new_value(1, Provenance::Synthetic);
+        let create = SV::new_synthetic(
+            2,
+            SVD::Create {
+                value: value.clone(),
+                data:  data.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let [value_tv, data_tv, create_tv] = state.register_many([value, data, create.clone()]);
+        CreateContractRule.infer(&create, &mut state)?;
+
+        // Check that the equations are right
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(data_tv).is_empty());
+        assert!(state.inferences(create_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_create2() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let data = SV::new_value(1, Provenance::Synthetic);
+        let salt = SV::new_value(2, Provenance::Synthetic);
+        let create = SV::new_synthetic(
+            3,
+            SVD::Create2 {
+                value: value.clone(),
+                salt:  salt.clone(),
+                data:  data.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let [value_tv, salt_tv, data_tv, create_tv] =
+            state.register_many([value, salt, data, create.clone()]);
+        CreateContractRule.infer(&create, &mut state)?;
+
+        // Check that the equations are right
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(salt_tv).contains(&TE::bytes(Some(WORD_SIZE))));
+        assert!(state.inferences(data_tv).is_empty());
+        assert!(state.inferences(create_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/dynamic_array_write.rs
+++ b/src/unifier/inference_rule/dynamic_array_write.rs
@@ -2,11 +2,8 @@
 //! array writes.
 
 use crate::{
-    unifier::{
-        expression::TE,
-        inference_rule::InferenceRule,
-        state::{TypeVariable, TypingState},
-    },
+    error::unification::Result,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
     vm::value::{BoxedVal, SVD},
 };
 
@@ -27,12 +24,7 @@ pub struct DynamicArrayWriteRule;
 
 impl InferenceRule for DynamicArrayWriteRule {
     #[allow(clippy::many_single_char_names)] // They correspond to the above spec
-    fn infer(
-        &self,
-        value: &BoxedVal,
-        _a_tv: TypeVariable,
-        state: &mut TypingState,
-    ) -> crate::error::unification::Result<()> {
+    fn infer(&self, value: &BoxedVal, state: &mut TypingState) -> Result<()> {
         let SVD::StorageWrite { key: b, value: g } = &value.data else { return Ok(()) };
         let SVD::StorageSlot { key: c } = &b.data else { return Ok(()) };
         let SVD::DynamicArrayAccess { slot: d, index: f } = &c.data else { return Ok(()) };
@@ -114,7 +106,7 @@ mod test {
         let a_tv = state.register(store.clone());
 
         // Run the inference rule
-        DynamicArrayWriteRule.infer(&store, a_tv, &mut state)?;
+        DynamicArrayWriteRule.infer(&store, &mut state)?;
 
         // Check that we end up with expected results in the state
         assert_eq!(state.inferences(g_tv).len(), 1);

--- a/src/unifier/inference_rule/environment_opcodes.rs
+++ b/src/unifier/inference_rule/environment_opcodes.rs
@@ -1,0 +1,350 @@
+//! This module contains an inference rule that deals with the basic types for a
+//! variety of symbolic values that result from interactions with the
+//! environment.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This inference rule deals with a number of symbolic expressions that occur
+/// from interactions with the environment. Many of them are terminals, in that
+/// they do not change depending on the course of execution, but all have fixed
+/// return types.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct EnvironmentCodesRule;
+
+impl InferenceRule for EnvironmentCodesRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::Address | SVD::Origin | SVD::Caller | SVD::CoinBase => {
+                state.infer_for(value, TE::address());
+            }
+            SVD::Balance { address } => {
+                state.infer_for(address, TE::address());
+                state.infer_for(value, TE::unsigned_word(None));
+            }
+            SVD::CallValue
+            | SVD::GasPrice
+            | SVD::BlockTimestamp
+            | SVD::BlockNumber
+            | SVD::Prevrandao
+            | SVD::GasLimit
+            | SVD::ChainId
+            | SVD::SelfBalance
+            | SVD::BaseFee
+            | SVD::Gas
+            | SVD::CallDataSize => {
+                state.infer_for(value, TE::unsigned_word(None));
+            }
+            SVD::SelfDestruct { target } => {
+                state.infer_for(target, TE::address());
+            }
+            _ => (),
+        };
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{environment_opcodes::EnvironmentCodesRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_address() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::Address);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_origin() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::Origin);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_caller() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::Caller);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_coin_base() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::CoinBase);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_balance() -> anyhow::Result<()> {
+        // Create a value
+        let address = SV::new_value(0, Provenance::Synthetic);
+        let value = SV::new_synthetic(
+            1,
+            SVD::Balance {
+                address: address.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let [value_tv, address_tv] = state.register_many([value.clone(), address]);
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_call_value() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::CallValue);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas_price() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::GasPrice);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_block_timestamp() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::BlockTimestamp);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_block_number() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::BlockNumber);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_prevrandao() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::Prevrandao);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas_limit() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::GasLimit);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_chain_id() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::ChainId);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_self_balance() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::SelfBalance);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_base_fee() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::BaseFee);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::Gas);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_call_data_size() -> anyhow::Result<()> {
+        // Create a value
+        let value = SV::new_synthetic(0, SVD::CallDataSize);
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let value_tv = state.register(value.clone());
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_self_destruct() -> anyhow::Result<()> {
+        // Create a value
+        let address = SV::new_value(0, Provenance::Synthetic);
+        let value = SV::new_synthetic(
+            1,
+            SVD::SelfDestruct {
+                target: address.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let [value_tv, address_tv] = state.register_many([value.clone(), address]);
+        EnvironmentCodesRule.infer(&value, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(value_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/ext_code.rs
+++ b/src/unifier/inference_rule/ext_code.rs
@@ -1,0 +1,122 @@
+//! This module contains an inference rule for dealing with values that relate
+//! to external code.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates inferences for dealing with external code.
+///
+/// For expressions of the form:
+///
+/// ```text
+/// ext_code_size(address)
+///       a          b
+/// ```
+///
+/// - `a = unsigned`
+/// - `b = address`
+///
+/// For expressions of the form:
+///
+/// ```text
+/// ext_code_copy(address, offset, size)
+///       a          b        c      d
+/// ```
+///
+/// - `b = address`
+/// - `c = unsigned`
+/// - `d = unsigned`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ExtCodeRule;
+
+impl InferenceRule for ExtCodeRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::ExtCodeSize { address } => {
+                state.infer_for(address, TE::address());
+                state.infer_for(value, TE::unsigned_word(None));
+            }
+            SVD::ExtCodeCopy {
+                address,
+                offset,
+                size,
+            } => {
+                state.infer_for_many([offset, size], TE::unsigned_word(None));
+                state.infer_for(address, TE::address());
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{ext_code::ExtCodeRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_ext_code_size() -> anyhow::Result<()> {
+        // Create some values
+        let address = SV::new_value(0, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            1,
+            SVD::ExtCodeSize {
+                address: address.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [address_tv, operator_tv] = state.register_many([address, operator.clone()]);
+        ExtCodeRule.infer(&operator, &mut state)?;
+
+        // Check we get the equations we want
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(operator_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_ext_code_copy() -> anyhow::Result<()> {
+        // Create some values
+        let address = SV::new_value(0, Provenance::Synthetic);
+        let offset = SV::new_value(1, Provenance::Synthetic);
+        let size = SV::new_value(2, Provenance::Synthetic);
+        let operator = SV::new_synthetic(
+            3,
+            SVD::ExtCodeCopy {
+                address: address.clone(),
+                offset:  offset.clone(),
+                size:    size.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = TypingState::empty();
+        let [address_tv, offset_tv, size_tv, operator_tv] =
+            state.register_many([address, offset, size, operator.clone()]);
+        ExtCodeRule.infer(&operator, &mut state)?;
+
+        // Check we get the equations we want
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(offset_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(size_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/external_calls.rs
+++ b/src/unifier/inference_rule/external_calls.rs
@@ -1,0 +1,200 @@
+//! This module contains the implementation of inference rules to do with
+//! external message calls.
+
+use crate::{
+    error::unification::Result,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the following equations for external calls.
+///
+/// For expressions of the form:
+///
+/// ```text
+/// call_with_value(gas, address, value, argument_data, ret_offset, ret_size)
+///        a         b      c       d          e             f          g
+/// ```
+///
+/// - `a = address`
+/// - `b = unsigned`
+/// - `c = address`
+/// - `d = unsigned`
+/// - `f = unsigned`
+/// - `g = unsigned`
+///
+/// For expressions of the form:
+///
+/// ```text
+/// call_without_value(gas, address, argument_data, ret_offset, ret_size)
+///         a           b      c           d             e          f
+/// ```
+///
+/// - `a = address`
+/// - `b = unsigned`
+/// - `c = address`
+/// - `e = unsigned`
+/// - `f = unsigned`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ExternalCallRule;
+
+impl InferenceRule for ExternalCallRule {
+    #[allow(clippy::many_single_char_names)] // They correspond to the above spec
+    fn infer(&self, value: &BoxedVal, state: &mut TypingState) -> Result<()> {
+        match &value.data {
+            SVD::CallWithValue {
+                gas: b,
+                address: c,
+                value: d,
+                ret_offset: f,
+                ret_size: g,
+                ..
+            } => {
+                // a = address
+                state.infer_for(value, TE::address());
+
+                // b = unsigned
+                state.infer_for(b, TE::unsigned_word(None));
+
+                // c = address
+                state.infer_for(c, TE::address());
+
+                // d = unsigned
+                state.infer_for(d, TE::unsigned_word(None));
+
+                // f = unsigned
+                state.infer_for(f, TE::unsigned_word(None));
+
+                // g = unsigned
+                state.infer_for(g, TE::unsigned_word(None));
+
+                Ok(())
+            }
+            SVD::CallWithoutValue {
+                gas: b,
+                address: c,
+                ret_offset: e,
+                ret_size: f,
+                ..
+            } => {
+                // a = address
+                state.infer_for(value, TE::address());
+
+                // b = unsigned
+                state.infer_for(b, TE::unsigned_word(None));
+
+                // c = address
+                state.infer_for(c, TE::address());
+
+                // e = unsigned
+                state.infer_for(e, TE::unsigned_word(None));
+
+                // f = unsigned
+                state.infer_for(f, TE::unsigned_word(None));
+
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{external_calls::ExternalCallRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    #[allow(clippy::many_single_char_names)] // They correspond to the above spec
+    fn creates_correct_equations_for_call_with_value() -> anyhow::Result<()> {
+        // Create some values
+        let ret_size = SV::new_value(0, Provenance::Synthetic);
+        let ret_offset = SV::new_value(1, Provenance::Synthetic);
+        let arg_data = SV::new_value(2, Provenance::Synthetic);
+        let value = SV::new_value(3, Provenance::Synthetic);
+        let address = SV::new_value(4, Provenance::Synthetic);
+        let gas = SV::new_value(5, Provenance::Synthetic);
+        let call = SV::new(
+            6,
+            SVD::CallWithValue {
+                gas:           gas.clone(),
+                address:       address.clone(),
+                value:         value.clone(),
+                argument_data: arg_data.clone(),
+                ret_offset:    ret_offset.clone(),
+                ret_size:      ret_size.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Create the state and register the values
+        let mut state = TypingState::empty();
+        let [g, f, _, d, c, b, a] = state.register_many([
+            ret_size,
+            ret_offset,
+            arg_data,
+            value,
+            address,
+            gas,
+            call.clone(),
+        ]);
+
+        // Run the rule
+        ExternalCallRule.infer(&call, &mut state)?;
+
+        // Check that the equations are correct
+        assert!(state.inferences(g).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(f).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(d).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(c).contains(&TE::address()));
+        assert!(state.inferences(b).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(a).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    #[allow(clippy::many_single_char_names)] // They correspond to the above spec
+    fn creates_correct_equations_for_call_without_value() -> anyhow::Result<()> {
+        // Create some values
+        let ret_size = SV::new_value(0, Provenance::Synthetic);
+        let ret_offset = SV::new_value(1, Provenance::Synthetic);
+        let arg_data = SV::new_value(2, Provenance::Synthetic);
+        let address = SV::new_value(4, Provenance::Synthetic);
+        let gas = SV::new_value(5, Provenance::Synthetic);
+        let call = SV::new(
+            6,
+            SVD::CallWithoutValue {
+                gas:           gas.clone(),
+                address:       address.clone(),
+                argument_data: arg_data.clone(),
+                ret_offset:    ret_offset.clone(),
+                ret_size:      ret_size.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Create the state and register the values
+        let mut state = TypingState::empty();
+        let [f, e, _, c, b, a] =
+            state.register_many([ret_size, ret_offset, arg_data, address, gas, call.clone()]);
+
+        // Run the rule
+        ExternalCallRule.infer(&call, &mut state)?;
+
+        // Check that the equations are correct
+        assert!(state.inferences(f).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(e).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(c).contains(&TE::address()));
+        assert!(state.inferences(b).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(a).contains(&TE::address()));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/offset_size.rs
+++ b/src/unifier/inference_rule/offset_size.rs
@@ -1,0 +1,125 @@
+//! This module contains an inference rule for dealing with data that is built
+//! from an offset into memory and a size.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the following equations for any expressions of the
+/// following form:
+///
+/// ```text
+///   call_data(id, offset, size)
+///   code_copy(    offset, size)
+/// return_data(    offset, size)
+///                    a      b
+/// ```
+///
+/// - `a = unsigned`
+/// - `b = unsigned`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct OffsetSizeRule;
+
+impl InferenceRule for OffsetSizeRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::CallData { offset, size, .. }
+            | SVD::CodeCopy { offset, size }
+            | SVD::ReturnData { offset, size } => {
+                state.infer_for_many([offset, size], TE::unsigned_word(None));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{offset_size::OffsetSizeRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_call_data() -> anyhow::Result<()> {
+        // Create some values
+        let offset = SV::new_value(0, Provenance::Synthetic);
+        let size = SV::new_value(1, Provenance::Synthetic);
+        let value = SV::new_synthetic(2, SVD::call_data(offset.clone(), size.clone()));
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [offset_tv, size_tv, value_tv] = state.register_many([offset, size, value.clone()]);
+        OffsetSizeRule.infer(&value, &mut state)?;
+
+        // Check that we get the correct equations
+        assert!(state.inferences(offset_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(size_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(value_tv).is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_code_copy() -> anyhow::Result<()> {
+        // Create some values
+        let offset = SV::new_value(0, Provenance::Synthetic);
+        let size = SV::new_value(1, Provenance::Synthetic);
+        let value = SV::new_synthetic(
+            2,
+            SVD::CodeCopy {
+                offset: offset.clone(),
+                size:   size.clone(),
+            },
+        );
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [offset_tv, size_tv, value_tv] = state.register_many([offset, size, value.clone()]);
+        OffsetSizeRule.infer(&value, &mut state)?;
+
+        // Check that we get the correct equations
+        assert!(state.inferences(offset_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(size_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(value_tv).is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_return_data() -> anyhow::Result<()> {
+        // Create some values
+        let offset = SV::new_value(0, Provenance::Synthetic);
+        let size = SV::new_value(1, Provenance::Synthetic);
+        let value = SV::new_synthetic(
+            2,
+            SVD::ReturnData {
+                offset: offset.clone(),
+                size:   size.clone(),
+            },
+        );
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [offset_tv, size_tv, value_tv] = state.register_many([offset, size, value.clone()]);
+        OffsetSizeRule.infer(&value, &mut state)?;
+
+        // Check that we get the correct equations
+        assert!(state.inferences(offset_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(size_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(value_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/sha3.rs
+++ b/src/unifier/inference_rule/sha3.rs
@@ -1,0 +1,95 @@
+//! This module contains inference rules related to encountering the `hash`
+//! opcodes.
+
+use crate::{
+    constant::WORD_SIZE,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule states that the output of the `SHA3` opcode is a `bytes32`, which
+/// is always true.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct HashRule;
+
+impl InferenceRule for HashRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        match &value.data {
+            SVD::Sha3 { .. } => {
+                state.infer_for(value, TE::bytes(Some(WORD_SIZE)));
+            }
+            SVD::ExtCodeHash { address } => {
+                state.infer_for(address, TE::address());
+                state.infer_for(value, TE::bytes(Some(WORD_SIZE)));
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        constant::WORD_SIZE,
+        unifier::{
+            expression::TE,
+            inference_rule::{sha3::HashRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_sha3() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let hash = SV::new(
+            1,
+            SVD::Sha3 {
+                data: value.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [value_tv, hash_tv] = state.register_many([value, hash.clone()]);
+        HashRule.infer(&hash, &mut state)?;
+
+        // Check we get the correct equations
+        assert!(state.inferences(value_tv).is_empty());
+        assert!(state.inferences(hash_tv).contains(&TE::bytes(Some(WORD_SIZE))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_ext_code_hash() -> anyhow::Result<()> {
+        // Create some values
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let hash = SV::new(
+            1,
+            SVD::ExtCodeHash {
+                address: value.clone(),
+            },
+            Provenance::Synthetic,
+        );
+
+        // Create the state and run the inference
+        let mut state = TypingState::empty();
+        let [value_tv, hash_tv] = state.register_many([value, hash.clone()]);
+        HashRule.infer(&hash, &mut state)?;
+
+        // Check we get the correct equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+        assert!(state.inferences(hash_tv).contains(&TE::bytes(Some(WORD_SIZE))));
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/storage_key.rs
+++ b/src/unifier/inference_rule/storage_key.rs
@@ -1,0 +1,60 @@
+//! This module contains an inference rule that says that the key used for a
+//! storage slot must be an unsigned integer.
+
+use crate::{
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This inference rule creates the equation `b = unsigned` for expressions of
+/// the following form.
+///
+/// ```text
+/// slot<key>
+///   a   b
+/// ```
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct StorageKeyRule;
+
+impl InferenceRule for StorageKeyRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut TypingState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::StorageSlot { key } = &value.data else { return Ok(()) };
+        state.infer_for(key, TE::unsigned_word(None));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        unifier::{
+            expression::TE,
+            inference_rule::{storage_key::StorageKeyRule, InferenceRule},
+            state::TypingState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn storage_keys_get_correct_equation() -> anyhow::Result<()> {
+        // Create some values
+        let key = SV::new_value(0, Provenance::Synthetic);
+        let slot = SV::new_synthetic(1, SVD::StorageSlot { key: key.clone() });
+
+        // Create the state and run inference
+        let mut state = TypingState::empty();
+        let [key_tv, slot_tv] = state.register_many([key, slot.clone()]);
+        StorageKeyRule.infer(&slot, &mut state)?;
+
+        // Check we get the equations
+        assert!(state.inferences(key_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(slot_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/unifier/inference_rule/storage_write.rs
+++ b/src/unifier/inference_rule/storage_write.rs
@@ -2,11 +2,8 @@
 //! storage slots to the types of their contained values.
 
 use crate::{
-    unifier::{
-        expression::TE,
-        inference_rule::InferenceRule,
-        state::{TypeVariable, TypingState},
-    },
+    error::unification::Result,
+    unifier::{expression::TE, inference_rule::InferenceRule, state::TypingState},
     vm::value::{BoxedVal, SVD},
 };
 
@@ -16,12 +13,7 @@ use crate::{
 pub struct StorageWriteRule;
 
 impl InferenceRule for StorageWriteRule {
-    fn infer(
-        &self,
-        value: &BoxedVal,
-        _ty_var: TypeVariable,
-        state: &mut TypingState,
-    ) -> crate::error::unification::Result<()> {
+    fn infer(&self, value: &BoxedVal, state: &mut TypingState) -> Result<()> {
         match &value.data {
             SVD::StorageWrite { key, value } => {
                 // An equality for the key's type
@@ -75,7 +67,7 @@ mod test {
         let write_tv = state.register(write.clone());
 
         // Run the inference rule
-        StorageWriteRule.infer(&write, write_tv, &mut state)?;
+        StorageWriteRule.infer(&write, &mut state)?;
 
         // Check that the equalities hold and that we only get the judgements we expect
         assert_eq!(state.inferences(key_tv).len(), 1);


### PR DESCRIPTION
# Summary

For any immediately obvious type inference that can be made from each node in the tree of Symbolic Values, we now have an inference rule that associates that type information with those nodes.

None of the rules in this commit are complex, and they are not intended to be so.

# Details

I apologise for how huge this is, though most of that size is tests. The inference rules themselves are comparatively small. 

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
