### PR TITLE
Implement discovery of packed encodings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 # Environment variables that will be set on all runners
 env:
-  RUST_VERSION: 1.70.0       # Specify the Rust version to be used on CI.
+  RUST_VERSION: 1.71.0       # Specify the Rust version to be used on CI.
   CARGO_TERM_COLOR: always   # Always colour Cargo's output.
   CARGO_INCREMENTAL: 0       # Always run without incremental builds on CI.
   CARGO_PROFILE_DEV_DEBUG: 0 # Don't embed debug info even though the build is a dev build.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ readme = "README.md"
 # to let authors opt in to backwards-incompatible changes. Crates using one edition can interoperate with crates using
 # another edition, thereby ensuring that there's no ecosystem split.
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.71.0"
 
 # Prevent publishing by accident.
 publish = false
@@ -32,19 +32,19 @@ derivative = "2.2.0"
 downcast-rs = "1.2.0"
 ethnum = "1.3.2"
 hex = "0.4.3"
-itertools = "0.10.5"
-serde = { version = "1.0.163", features = ["derive"] }
+itertools = "0.11.0"
+serde = { version = "1.0.180", features = ["derive"] }
 sha3 = "0.10.8"
-thiserror = "1.0.40"
-uuid = { version = "1.3.2", features = ["v4", "fast-rng", "macro-diagnostics"] }
+thiserror = "1.0.44"
+uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 # Dev dependencies.
 #
 # These are the dependencies required purely for internal development of the library such as testing or benchmarking.
 [dev-dependencies]
-anyhow = { version = "1.0.71", features = ["backtrace"] }
+anyhow = { version = "1.0.72", features = ["backtrace"] }
 rand = "0.8.5"
-serde_json = "1.0.96"
+serde_json = "1.0.104"
 
 # Profiles specify the build settings for different kinds of build.
 #
@@ -63,7 +63,7 @@ incremental = true      # Ensure that incremental builds are enabled for dev. Th
 # Configuration for release builds
 [profile.release]
 opt-level = 3            # Compile with all of the optimisations in production builds. This is the default.
-debug = 1                # Include just line tables in release builds.
+debug = true             # Include full debug information in release builds.
 debug-assertions = false # Disable in release builds for speed. This is the default.
 overflow-checks = true   # Keep overflow checks in production builds.
 lto = "thin"             # Thin LTO performs cross-crate LTO while not bloating the build time too much.

--- a/asset/PackedEncodings.json
+++ b/asset/PackedEncodings.json
@@ -1,73 +1,6 @@
 {
   "abi": [
     {
-      "inputs": [],
-      "name": "get_current",
-      "outputs": [
-        {
-          "components": [
-            {
-              "internalType": "address",
-              "name": "addr",
-              "type": "address"
-            },
-            {
-              "internalType": "bool",
-              "name": "isEnabled",
-              "type": "bool"
-            }
-          ],
-          "internalType": "struct BytecodeExample.StructTwo",
-          "name": "",
-          "type": "tuple"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "history",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "addr",
-          "type": "address"
-        },
-        {
-          "internalType": "bool",
-          "name": "isEnabled",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "addr",
-          "type": "address"
-        },
-        {
-          "internalType": "bool",
-          "name": "isEnabled",
-          "type": "bool"
-        }
-      ],
-      "name": "new_current",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
       "inputs": [
         {
           "internalType": "uint64",
@@ -87,95 +20,26 @@
     }
   ],
   "bytecode": {
-    "object": "0x608060405234801561001057600080fd5b506102db806100206000396000f3fe608060405234801561001057600080fd5b506004361061004c5760003560e01c80631b78187d1461005157806374878662146100aa57806377ef0222146100f5578063a7a38f0b14610194575b600080fd5b6040805180820182526000808252602091820152815180830183526001546001600160a01b038116808352600160a01b90910460ff16151591830191825283519081529051151591810191909152015b60405180910390f35b6100f36100b83660046101fb565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b6100f361010336600461024d565b600280546001818101835560009290925281547f405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace90910180546001600160a01b031981166001600160a01b039384169081178355845460ff600160a01b9182900416151581026001600160a81b03199384169092179190911790925583549415159091029316931692909217179055565b6101a76101a236600461028c565b6101c6565b604080516001600160a01b0390931683529015156020830152016100a1565b600281815481106101d657600080fd5b6000918252602090912001546001600160a01b0381169150600160a01b900460ff1682565b6000806040838503121561020e57600080fd5b823567ffffffffffffffff8116811461022657600080fd5b915060208301356001600160801b038116811461024257600080fd5b809150509250929050565b6000806040838503121561026057600080fd5b82356001600160a01b038116811461027757600080fd5b91506020830135801515811461024257600080fd5b60006020828403121561029e57600080fd5b503591905056fea26469706673582212207e31853dcb00b2dc55692d5f3ac5badce0163a15f68777de5100a54291a7171f64736f6c63430008130033",
-    "sourceMap": "65:1110:13:-:0;;;;;;;;;;;;;;;;;;;",
+    "object": "0x608060405234801561001057600080fd5b5060fa8061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80637487866214602d575b600080fd5b607360383660046075565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b60008060408385031215608757600080fd5b823567ffffffffffffffff81168114609e57600080fd5b915060208301356001600160801b038116811460b957600080fd5b80915050925092905056fea26469706673582212201cf953c228d34054f8000f54f4343aa616b0f913e8b736e93bc9783f73a23b9364736f6c63430008150033",
+    "sourceMap": "65:1152:19:-:0;;;;;;;;;;;;;;;;;;;",
     "linkReferences": {}
   },
   "deployedBytecode": {
-    "object": "0x608060405234801561001057600080fd5b506004361061004c5760003560e01c80631b78187d1461005157806374878662146100aa57806377ef0222146100f5578063a7a38f0b14610194575b600080fd5b6040805180820182526000808252602091820152815180830183526001546001600160a01b038116808352600160a01b90910460ff16151591830191825283519081529051151591810191909152015b60405180910390f35b6100f36100b83660046101fb565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b6100f361010336600461024d565b600280546001818101835560009290925281547f405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace90910180546001600160a01b031981166001600160a01b039384169081178355845460ff600160a01b9182900416151581026001600160a81b03199384169092179190911790925583549415159091029316931692909217179055565b6101a76101a236600461028c565b6101c6565b604080516001600160a01b0390931683529015156020830152016100a1565b600281815481106101d657600080fd5b6000918252602090912001546001600160a01b0381169150600160a01b900460ff1682565b6000806040838503121561020e57600080fd5b823567ffffffffffffffff8116811461022657600080fd5b915060208301356001600160801b038116811461024257600080fd5b809150509250929050565b6000806040838503121561026057600080fd5b82356001600160a01b038116811461027757600080fd5b91506020830135801515811461024257600080fd5b60006020828403121561029e57600080fd5b503591905056fea26469706673582212207e31853dcb00b2dc55692d5f3ac5badce0163a15f68777de5100a54291a7171f64736f6c63430008130033",
-    "sourceMap": "65:1110:13:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;1080:93;-1:-1:-1;;;;;;;;;;;;;;;;;1152:14:13;;;;;;;1159:7;1152:14;-1:-1:-1;;;;;1152:14:13;;;;;-1:-1:-1;;;1152:14:13;;;;;;;;;;;;;1080:93;;216:58:14;;;326:24;;319:32;312:40;290:20;;;283:70;;;;189:18;1080:93:13;;;;;;;;704:105;;;;;;:::i;:::-;764:4;:14;;-1:-1:-1;;;;;788:14:13;;;;;-1:-1:-1;;;;;;788:14:13;;;764;;;;788;;;;;;;704:105;;;878:164;;;;;;:::i;:::-;946:7;:21;;959:7;946:21;;;;;-1:-1:-1;946:21:13;;;;;;;;;;;;-1:-1:-1;;;;;;946:21:13;;-1:-1:-1;;;;;946:21:13;;;;;;;;;;;-1:-1:-1;;;946:21:13;;;;;;;;;-1:-1:-1;;;;;;946:21:13;;;;;;;;;;;;;977:19;;1006:29;;;;;;;;977:19;;1006:29;;;;;;;878:164;671:26;;;;;;:::i;:::-;;:::i;:::-;;;;-1:-1:-1;;;;;1681:32:14;;;1663:51;;1757:14;;1750:22;1745:2;1730:18;;1723:50;1636:18;671:26:13;1495:284:14;671:26:13;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;;;;;671:26:13;;;-1:-1:-1;;;;671:26:13;;;;;:::o;364:481:14:-;431:6;439;492:2;480:9;471:7;467:23;463:32;460:52;;;508:1;505;498:12;460:52;547:9;534:23;597:18;590:5;586:30;579:5;576:41;566:69;;631:1;628;621:12;566:69;654:5;-1:-1:-1;711:2:14;696:18;;683:32;-1:-1:-1;;;;;746:48:14;;734:61;;724:89;;809:1;806;799:12;724:89;832:7;822:17;;;364:481;;;;;:::o;850:455::-;915:6;923;976:2;964:9;955:7;951:23;947:32;944:52;;;992:1;989;982:12;944:52;1018:23;;-1:-1:-1;;;;;1070:31:14;;1060:42;;1050:70;;1116:1;1113;1106:12;1050:70;1139:5;-1:-1:-1;1196:2:14;1181:18;;1168:32;1238:15;;1231:23;1219:36;;1209:64;;1269:1;1266;1259:12;1310:180;1369:6;1422:2;1410:9;1401:7;1397:23;1393:32;1390:52;;;1438:1;1435;1428:12;1390:52;-1:-1:-1;1461:23:14;;1310:180;-1:-1:-1;1310:180:14:o",
+    "object": "0x6080604052348015600f57600080fd5b506004361060285760003560e01c80637487866214602d575b600080fd5b607360383660046075565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b60008060408385031215608757600080fd5b823567ffffffffffffffff81168114609e57600080fd5b915060208301356001600160801b038116811460b957600080fd5b80915050925092905056fea26469706673582212201cf953c228d34054f8000f54f4343aa616b0f913e8b736e93bc9783f73a23b9364736f6c63430008150033",
+    "sourceMap": "65:1152:19:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;722:105;;;;;;:::i;:::-;782:4;:14;;-1:-1:-1;;;;;806:14:19;;;;;-1:-1:-1;;;;;;806:14:19;;;782;;;;806;;;;;;;722:105;;;14:481:21;81:6;89;142:2;130:9;121:7;117:23;113:32;110:52;;;158:1;155;148:12;110:52;197:9;184:23;247:18;240:5;236:30;229:5;226:41;216:69;;281:1;278;271:12;216:69;304:5;-1:-1:-1;361:2:21;346:18;;333:32;-1:-1:-1;;;;;396:48:21;;384:61;;374:89;;459:1;456;449:12;374:89;482:7;472:17;;;14:481;;;;;:::o",
     "linkReferences": {}
   },
   "methodIdentifiers": {
-    "get_current()": "1b78187d",
-    "history(uint256)": "a7a38f0b",
-    "new_current(address,bool)": "77ef0222",
     "set_data(uint64,uint128)": "74878662"
   },
-  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.19+commit.7dd6d404\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[],\"name\":\"get_current\",\"outputs\":[{\"components\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isEnabled\",\"type\":\"bool\"}],\"internalType\":\"struct BytecodeExample.StructTwo\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"history\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isEnabled\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"},{\"internalType\":\"bool\",\"name\":\"isEnabled\",\"type\":\"bool\"}],\"name\":\"new_current\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"one\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"two\",\"type\":\"uint128\"}],\"name\":\"set_data\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/BytecodeExample.sol\":\"BytecodeExample\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":ds-test/=lib/forge-std/lib/ds-test/src/\",\":forge-std/=lib/forge-std/src/\"]},\"sources\":{\"src/BytecodeExample.sol\":{\"keccak256\":\"0x907067fed65939af2ce0fe0ecaf326fb48be4f1a9bb6274da45e46fb8c3f036b\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://45a6bea4de63834587fb2ac66a11e7c196aa467ce063fc60a69eb51811a50468\",\"dweb:/ipfs/QmSFWfafcnVWXz6zY3jer5U7uUeXXNbvXi3qQqPBhWdRo5\"]}},\"version\":1}",
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.21+commit.d9974bed\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"one\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"two\",\"type\":\"uint128\"}],\"name\":\"set_data\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/BytecodeExample.sol\":\"BytecodeExample\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":ds-test/=lib/forge-std/lib/ds-test/src/\",\":forge-std/=lib/forge-std/src/\"]},\"sources\":{\"src/BytecodeExample.sol\":{\"keccak256\":\"0x8829bfc0f0a1a82518ce2b2cc7f47806d5bb5682f26cebe685543b71b2198af3\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://2d8520ef8f53ac582e8833b1ca18fd26d3acb33095fb9ad4e7a0eb9401270491\",\"dweb:/ipfs/QmQjGHJdFFBeFBkubXHzBH6w4rvDah7atjPruNFRqt6srv\"]}},\"version\":1}",
   "metadata": {
     "compiler": {
-      "version": "0.8.19+commit.7dd6d404"
+      "version": "0.8.21+commit.d9974bed"
     },
     "language": "Solidity",
     "output": {
       "abi": [
-        {
-          "inputs": [],
-          "stateMutability": "view",
-          "type": "function",
-          "name": "get_current",
-          "outputs": [
-            {
-              "internalType": "struct BytecodeExample.StructTwo",
-              "name": "",
-              "type": "tuple",
-              "components": [
-                {
-                  "internalType": "address",
-                  "name": "addr",
-                  "type": "address"
-                },
-                {
-                  "internalType": "bool",
-                  "name": "isEnabled",
-                  "type": "bool"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function",
-          "name": "history",
-          "outputs": [
-            {
-              "internalType": "address",
-              "name": "addr",
-              "type": "address"
-            },
-            {
-              "internalType": "bool",
-              "name": "isEnabled",
-              "type": "bool"
-            }
-          ]
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "addr",
-              "type": "address"
-            },
-            {
-              "internalType": "bool",
-              "name": "isEnabled",
-              "type": "bool"
-            }
-          ],
-          "stateMutability": "nonpayable",
-          "type": "function",
-          "name": "new_current"
-        },
         {
           "inputs": [
             {
@@ -207,8 +71,8 @@
     },
     "settings": {
       "remappings": [
-        ":ds-test/=lib/forge-std/lib/ds-test/src/",
-        ":forge-std/=lib/forge-std/src/"
+        "ds-test/=lib/forge-std/lib/ds-test/src/",
+        "forge-std/=lib/forge-std/src/"
       ],
       "optimizer": {
         "enabled": true,
@@ -224,10 +88,10 @@
     },
     "sources": {
       "src/BytecodeExample.sol": {
-        "keccak256": "0x907067fed65939af2ce0fe0ecaf326fb48be4f1a9bb6274da45e46fb8c3f036b",
+        "keccak256": "0x8829bfc0f0a1a82518ce2b2cc7f47806d5bb5682f26cebe685543b71b2198af3",
         "urls": [
-          "bzz-raw://45a6bea4de63834587fb2ac66a11e7c196aa467ce063fc60a69eb51811a50468",
-          "dweb:/ipfs/QmSFWfafcnVWXz6zY3jer5U7uUeXXNbvXi3qQqPBhWdRo5"
+          "bzz-raw://2d8520ef8f53ac582e8833b1ca18fd26d3acb33095fb9ad4e7a0eb9401270491",
+          "dweb:/ipfs/QmQjGHJdFFBeFBkubXHzBH6w4rvDah7atjPruNFRqt6srv"
         ],
         "license": "UNLICENSED"
       }
@@ -236,19 +100,19 @@
   },
   "ast": {
     "absolutePath": "src/BytecodeExample.sol",
-    "id": 23991,
+    "id": 29204,
     "exportedSymbols": {
       "BytecodeExample": [
-        23990
+        29203
       ]
     },
     "nodeType": "SourceUnit",
-    "src": "39:1137:13",
+    "src": "39:1179:19",
     "nodes": [
       {
-        "id": 23914,
+        "id": 29174,
         "nodeType": "PragmaDirective",
-        "src": "39:24:13",
+        "src": "39:24:19",
         "nodes": [],
         "literals": [
           "solidity",
@@ -258,26 +122,26 @@
         ]
       },
       {
-        "id": 23990,
+        "id": 29203,
         "nodeType": "ContractDefinition",
-        "src": "65:1110:13",
+        "src": "65:1152:19",
         "nodes": [
           {
-            "id": 23919,
+            "id": 29179,
             "nodeType": "StructDefinition",
-            "src": "228:65:13",
+            "src": "228:65:19",
             "nodes": [],
             "canonicalName": "BytecodeExample.StructOne",
             "members": [
               {
                 "constant": false,
-                "id": 23916,
+                "id": 29176,
                 "mutability": "mutable",
                 "name": "one",
-                "nameLocation": "262:3:13",
+                "nameLocation": "262:3:19",
                 "nodeType": "VariableDeclaration",
-                "scope": 23919,
-                "src": "255:10:13",
+                "scope": 29179,
+                "src": "255:10:19",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -285,10 +149,10 @@
                   "typeString": "uint64"
                 },
                 "typeName": {
-                  "id": 23915,
+                  "id": 29175,
                   "name": "uint64",
                   "nodeType": "ElementaryTypeName",
-                  "src": "255:6:13",
+                  "src": "255:6:19",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint64",
                     "typeString": "uint64"
@@ -298,13 +162,13 @@
               },
               {
                 "constant": false,
-                "id": 23918,
+                "id": 29178,
                 "mutability": "mutable",
                 "name": "two",
-                "nameLocation": "283:3:13",
+                "nameLocation": "283:3:19",
                 "nodeType": "VariableDeclaration",
-                "scope": 23919,
-                "src": "275:11:13",
+                "scope": 29179,
+                "src": "275:11:19",
                 "stateVariable": false,
                 "storageLocation": "default",
                 "typeDescriptions": {
@@ -312,10 +176,10 @@
                   "typeString": "uint128"
                 },
                 "typeName": {
-                  "id": 23917,
+                  "id": 29177,
                   "name": "uint128",
                   "nodeType": "ElementaryTypeName",
-                  "src": "275:7:13",
+                  "src": "275:7:19",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint128",
                     "typeString": "uint128"
@@ -325,243 +189,89 @@
               }
             ],
             "name": "StructOne",
-            "nameLocation": "235:9:13",
-            "scope": 23990,
+            "nameLocation": "235:9:19",
+            "scope": 29203,
             "visibility": "public"
           },
           {
-            "id": 23924,
-            "nodeType": "StructDefinition",
-            "src": "349:70:13",
-            "nodes": [],
-            "canonicalName": "BytecodeExample.StructTwo",
-            "members": [
-              {
-                "constant": false,
-                "id": 23921,
-                "mutability": "mutable",
-                "name": "addr",
-                "nameLocation": "384:4:13",
-                "nodeType": "VariableDeclaration",
-                "scope": 23924,
-                "src": "376:12:13",
-                "stateVariable": false,
-                "storageLocation": "default",
-                "typeDescriptions": {
-                  "typeIdentifier": "t_address",
-                  "typeString": "address"
-                },
-                "typeName": {
-                  "id": 23920,
-                  "name": "address",
-                  "nodeType": "ElementaryTypeName",
-                  "src": "376:7:13",
-                  "stateMutability": "nonpayable",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  }
-                },
-                "visibility": "internal"
-              },
-              {
-                "constant": false,
-                "id": 23923,
-                "mutability": "mutable",
-                "name": "isEnabled",
-                "nameLocation": "403:9:13",
-                "nodeType": "VariableDeclaration",
-                "scope": 23924,
-                "src": "398:14:13",
-                "stateVariable": false,
-                "storageLocation": "default",
-                "typeDescriptions": {
-                  "typeIdentifier": "t_bool",
-                  "typeString": "bool"
-                },
-                "typeName": {
-                  "id": 23922,
-                  "name": "bool",
-                  "nodeType": "ElementaryTypeName",
-                  "src": "398:4:13",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bool",
-                    "typeString": "bool"
-                  }
-                },
-                "visibility": "internal"
-              }
-            ],
-            "name": "StructTwo",
-            "nameLocation": "356:9:13",
-            "scope": 23990,
-            "visibility": "public"
-          },
-          {
-            "id": 23927,
+            "id": 29182,
             "nodeType": "VariableDeclaration",
-            "src": "468:23:13",
+            "src": "480:23:19",
             "nodes": [],
             "constant": false,
             "mutability": "mutable",
             "name": "data",
-            "nameLocation": "487:4:13",
-            "scope": 23990,
+            "nameLocation": "499:4:19",
+            "scope": 29203,
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_struct$_StructOne_$23919_storage",
+              "typeIdentifier": "t_struct$_StructOne_$29179_storage",
               "typeString": "struct BytecodeExample.StructOne"
             },
             "typeName": {
-              "id": 23926,
+              "id": 29181,
               "nodeType": "UserDefinedTypeName",
               "pathNode": {
-                "id": 23925,
+                "id": 29180,
                 "name": "StructOne",
                 "nameLocations": [
-                  "468:9:13"
+                  "480:9:19"
                 ],
                 "nodeType": "IdentifierPath",
-                "referencedDeclaration": 23919,
-                "src": "468:9:13"
+                "referencedDeclaration": 29179,
+                "src": "480:9:19"
               },
-              "referencedDeclaration": 23919,
-              "src": "468:9:13",
+              "referencedDeclaration": 29179,
+              "src": "480:9:19",
               "typeDescriptions": {
-                "typeIdentifier": "t_struct$_StructOne_$23919_storage_ptr",
+                "typeIdentifier": "t_struct$_StructOne_$29179_storage_ptr",
                 "typeString": "struct BytecodeExample.StructOne"
               }
             },
             "visibility": "internal"
           },
           {
-            "id": 23930,
-            "nodeType": "VariableDeclaration",
-            "src": "639:26:13",
-            "nodes": [],
-            "constant": false,
-            "mutability": "mutable",
-            "name": "current",
-            "nameLocation": "658:7:13",
-            "scope": 23990,
-            "stateVariable": true,
-            "storageLocation": "default",
-            "typeDescriptions": {
-              "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-              "typeString": "struct BytecodeExample.StructTwo"
-            },
-            "typeName": {
-              "id": 23929,
-              "nodeType": "UserDefinedTypeName",
-              "pathNode": {
-                "id": 23928,
-                "name": "StructTwo",
-                "nameLocations": [
-                  "639:9:13"
-                ],
-                "nodeType": "IdentifierPath",
-                "referencedDeclaration": 23924,
-                "src": "639:9:13"
-              },
-              "referencedDeclaration": 23924,
-              "src": "639:9:13",
-              "typeDescriptions": {
-                "typeIdentifier": "t_struct$_StructTwo_$23924_storage_ptr",
-                "typeString": "struct BytecodeExample.StructTwo"
-              }
-            },
-            "visibility": "internal"
-          },
-          {
-            "id": 23934,
-            "nodeType": "VariableDeclaration",
-            "src": "671:26:13",
-            "nodes": [],
-            "constant": false,
-            "functionSelector": "a7a38f0b",
-            "mutability": "mutable",
-            "name": "history",
-            "nameLocation": "690:7:13",
-            "scope": 23990,
-            "stateVariable": true,
-            "storageLocation": "default",
-            "typeDescriptions": {
-              "typeIdentifier": "t_array$_t_struct$_StructTwo_$23924_storage_$dyn_storage",
-              "typeString": "struct BytecodeExample.StructTwo[]"
-            },
-            "typeName": {
-              "baseType": {
-                "id": 23932,
-                "nodeType": "UserDefinedTypeName",
-                "pathNode": {
-                  "id": 23931,
-                  "name": "StructTwo",
-                  "nameLocations": [
-                    "671:9:13"
-                  ],
-                  "nodeType": "IdentifierPath",
-                  "referencedDeclaration": 23924,
-                  "src": "671:9:13"
-                },
-                "referencedDeclaration": 23924,
-                "src": "671:9:13",
-                "typeDescriptions": {
-                  "typeIdentifier": "t_struct$_StructTwo_$23924_storage_ptr",
-                  "typeString": "struct BytecodeExample.StructTwo"
-                }
-              },
-              "id": 23933,
-              "nodeType": "ArrayTypeName",
-              "src": "671:11:13",
-              "typeDescriptions": {
-                "typeIdentifier": "t_array$_t_struct$_StructTwo_$23924_storage_$dyn_storage_ptr",
-                "typeString": "struct BytecodeExample.StructTwo[]"
-              }
-            },
-            "visibility": "public"
-          },
-          {
-            "id": 23954,
+            "id": 29202,
             "nodeType": "FunctionDefinition",
-            "src": "704:105:13",
+            "src": "722:105:19",
             "nodes": [],
             "body": {
-              "id": 23953,
+              "id": 29201,
               "nodeType": "Block",
-              "src": "754:55:13",
+              "src": "772:55:19",
               "nodes": [],
               "statements": [
                 {
                   "expression": {
-                    "id": 23945,
+                    "id": 29193,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "expression": {
-                        "id": 23941,
+                        "id": 29189,
                         "name": "data",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 23927,
-                        "src": "764:4:13",
+                        "referencedDeclaration": 29182,
+                        "src": "782:4:19",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_StructOne_$23919_storage",
+                          "typeIdentifier": "t_struct$_StructOne_$29179_storage",
                           "typeString": "struct BytecodeExample.StructOne storage ref"
                         }
                       },
-                      "id": 23943,
+                      "id": 29191,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
                       "lValueRequested": true,
-                      "memberLocation": "769:3:13",
+                      "memberLocation": "787:3:19",
                       "memberName": "one",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 23916,
-                      "src": "764:8:13",
+                      "referencedDeclaration": 29176,
+                      "src": "782:8:19",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint64",
                         "typeString": "uint64"
@@ -570,57 +280,57 @@
                     "nodeType": "Assignment",
                     "operator": "=",
                     "rightHandSide": {
-                      "id": 23944,
+                      "id": 29192,
                       "name": "one",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 23936,
-                      "src": "775:3:13",
+                      "referencedDeclaration": 29184,
+                      "src": "793:3:19",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint64",
                         "typeString": "uint64"
                       }
                     },
-                    "src": "764:14:13",
+                    "src": "782:14:19",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
                     }
                   },
-                  "id": 23946,
+                  "id": 29194,
                   "nodeType": "ExpressionStatement",
-                  "src": "764:14:13"
+                  "src": "782:14:19"
                 },
                 {
                   "expression": {
-                    "id": 23951,
+                    "id": 29199,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
                       "expression": {
-                        "id": 23947,
+                        "id": 29195,
                         "name": "data",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 23927,
-                        "src": "788:4:13",
+                        "referencedDeclaration": 29182,
+                        "src": "806:4:19",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_StructOne_$23919_storage",
+                          "typeIdentifier": "t_struct$_StructOne_$29179_storage",
                           "typeString": "struct BytecodeExample.StructOne storage ref"
                         }
                       },
-                      "id": 23949,
+                      "id": 29197,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
                       "lValueRequested": true,
-                      "memberLocation": "793:3:13",
+                      "memberLocation": "811:3:19",
                       "memberName": "two",
                       "nodeType": "MemberAccess",
-                      "referencedDeclaration": 23918,
-                      "src": "788:8:13",
+                      "referencedDeclaration": 29178,
+                      "src": "806:8:19",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint128",
                         "typeString": "uint128"
@@ -629,26 +339,26 @@
                     "nodeType": "Assignment",
                     "operator": "=",
                     "rightHandSide": {
-                      "id": 23950,
+                      "id": 29198,
                       "name": "two",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 23938,
-                      "src": "799:3:13",
+                      "referencedDeclaration": 29186,
+                      "src": "817:3:19",
                       "typeDescriptions": {
                         "typeIdentifier": "t_uint128",
                         "typeString": "uint128"
                       }
                     },
-                    "src": "788:14:13",
+                    "src": "806:14:19",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint128",
                       "typeString": "uint128"
                     }
                   },
-                  "id": 23952,
+                  "id": 29200,
                   "nodeType": "ExpressionStatement",
-                  "src": "788:14:13"
+                  "src": "806:14:19"
                 }
               ]
             },
@@ -657,20 +367,20 @@
             "kind": "function",
             "modifiers": [],
             "name": "set_data",
-            "nameLocation": "713:8:13",
+            "nameLocation": "731:8:19",
             "parameters": {
-              "id": 23939,
+              "id": 29187,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 23936,
+                  "id": 29184,
                   "mutability": "mutable",
                   "name": "one",
-                  "nameLocation": "729:3:13",
+                  "nameLocation": "747:3:19",
                   "nodeType": "VariableDeclaration",
-                  "scope": 23954,
-                  "src": "722:10:13",
+                  "scope": 29202,
+                  "src": "740:10:19",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -678,10 +388,10 @@
                     "typeString": "uint64"
                   },
                   "typeName": {
-                    "id": 23935,
+                    "id": 29183,
                     "name": "uint64",
                     "nodeType": "ElementaryTypeName",
-                    "src": "722:6:13",
+                    "src": "740:6:19",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint64",
                       "typeString": "uint64"
@@ -691,13 +401,13 @@
                 },
                 {
                   "constant": false,
-                  "id": 23938,
+                  "id": 29186,
                   "mutability": "mutable",
                   "name": "two",
-                  "nameLocation": "742:3:13",
+                  "nameLocation": "760:3:19",
                   "nodeType": "VariableDeclaration",
-                  "scope": 23954,
-                  "src": "734:11:13",
+                  "scope": 29202,
+                  "src": "752:11:19",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -705,10 +415,10 @@
                     "typeString": "uint128"
                   },
                   "typeName": {
-                    "id": 23937,
+                    "id": 29185,
                     "name": "uint128",
                     "nodeType": "ElementaryTypeName",
-                    "src": "734:7:13",
+                    "src": "752:7:19",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint128",
                       "typeString": "uint128"
@@ -717,387 +427,16 @@
                   "visibility": "internal"
                 }
               ],
-              "src": "721:25:13"
+              "src": "739:25:19"
             },
             "returnParameters": {
-              "id": 23940,
+              "id": 29188,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "754:0:13"
+              "src": "772:0:19"
             },
-            "scope": 23990,
+            "scope": 29203,
             "stateMutability": "nonpayable",
-            "virtual": false,
-            "visibility": "public"
-          },
-          {
-            "id": 23980,
-            "nodeType": "FunctionDefinition",
-            "src": "878:164:13",
-            "nodes": [],
-            "body": {
-              "id": 23979,
-              "nodeType": "Block",
-              "src": "936:106:13",
-              "nodes": [],
-              "statements": [
-                {
-                  "expression": {
-                    "arguments": [
-                      {
-                        "id": 23964,
-                        "name": "current",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 23930,
-                        "src": "959:7:13",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-                          "typeString": "struct BytecodeExample.StructTwo storage ref"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-                          "typeString": "struct BytecodeExample.StructTwo storage ref"
-                        }
-                      ],
-                      "expression": {
-                        "id": 23961,
-                        "name": "history",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 23934,
-                        "src": "946:7:13",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_array$_t_struct$_StructTwo_$23924_storage_$dyn_storage",
-                          "typeString": "struct BytecodeExample.StructTwo storage ref[] storage ref"
-                        }
-                      },
-                      "id": 23963,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": false,
-                      "lValueRequested": false,
-                      "memberLocation": "954:4:13",
-                      "memberName": "push",
-                      "nodeType": "MemberAccess",
-                      "src": "946:12:13",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_arraypush_nonpayable$_t_array$_t_struct$_StructTwo_$23924_storage_$dyn_storage_ptr_$_t_struct$_StructTwo_$23924_storage_$returns$__$attached_to$_t_array$_t_struct$_StructTwo_$23924_storage_$dyn_storage_ptr_$",
-                        "typeString": "function (struct BytecodeExample.StructTwo storage ref[] storage pointer,struct BytecodeExample.StructTwo storage ref)"
-                      }
-                    },
-                    "id": 23965,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "nameLocations": [],
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "946:21:13",
-                    "tryCall": false,
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 23966,
-                  "nodeType": "ExpressionStatement",
-                  "src": "946:21:13"
-                },
-                {
-                  "expression": {
-                    "id": 23971,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "expression": {
-                        "id": 23967,
-                        "name": "current",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 23930,
-                        "src": "977:7:13",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-                          "typeString": "struct BytecodeExample.StructTwo storage ref"
-                        }
-                      },
-                      "id": 23969,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberLocation": "985:4:13",
-                      "memberName": "addr",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 23921,
-                      "src": "977:12:13",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "id": 23970,
-                      "name": "addr",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 23956,
-                      "src": "992:4:13",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_address",
-                        "typeString": "address"
-                      }
-                    },
-                    "src": "977:19:13",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "id": 23972,
-                  "nodeType": "ExpressionStatement",
-                  "src": "977:19:13"
-                },
-                {
-                  "expression": {
-                    "id": 23977,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "leftHandSide": {
-                      "expression": {
-                        "id": 23973,
-                        "name": "current",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 23930,
-                        "src": "1006:7:13",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-                          "typeString": "struct BytecodeExample.StructTwo storage ref"
-                        }
-                      },
-                      "id": 23975,
-                      "isConstant": false,
-                      "isLValue": true,
-                      "isPure": false,
-                      "lValueRequested": true,
-                      "memberLocation": "1014:9:13",
-                      "memberName": "isEnabled",
-                      "nodeType": "MemberAccess",
-                      "referencedDeclaration": 23923,
-                      "src": "1006:17:13",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      }
-                    },
-                    "nodeType": "Assignment",
-                    "operator": "=",
-                    "rightHandSide": {
-                      "id": 23976,
-                      "name": "isEnabled",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 23958,
-                      "src": "1026:9:13",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_bool",
-                        "typeString": "bool"
-                      }
-                    },
-                    "src": "1006:29:13",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "id": 23978,
-                  "nodeType": "ExpressionStatement",
-                  "src": "1006:29:13"
-                }
-              ]
-            },
-            "functionSelector": "77ef0222",
-            "implemented": true,
-            "kind": "function",
-            "modifiers": [],
-            "name": "new_current",
-            "nameLocation": "887:11:13",
-            "parameters": {
-              "id": 23959,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 23956,
-                  "mutability": "mutable",
-                  "name": "addr",
-                  "nameLocation": "907:4:13",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 23980,
-                  "src": "899:12:13",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_address",
-                    "typeString": "address"
-                  },
-                  "typeName": {
-                    "id": 23955,
-                    "name": "address",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "899:7:13",
-                    "stateMutability": "nonpayable",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_address",
-                      "typeString": "address"
-                    }
-                  },
-                  "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 23958,
-                  "mutability": "mutable",
-                  "name": "isEnabled",
-                  "nameLocation": "918:9:13",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 23980,
-                  "src": "913:14:13",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_bool",
-                    "typeString": "bool"
-                  },
-                  "typeName": {
-                    "id": 23957,
-                    "name": "bool",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "913:4:13",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_bool",
-                      "typeString": "bool"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "898:30:13"
-            },
-            "returnParameters": {
-              "id": 23960,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "936:0:13"
-            },
-            "scope": 23990,
-            "stateMutability": "nonpayable",
-            "virtual": false,
-            "visibility": "public"
-          },
-          {
-            "id": 23989,
-            "nodeType": "FunctionDefinition",
-            "src": "1080:93:13",
-            "nodes": [],
-            "body": {
-              "id": 23988,
-              "nodeType": "Block",
-              "src": "1142:31:13",
-              "nodes": [],
-              "statements": [
-                {
-                  "expression": {
-                    "id": 23986,
-                    "name": "current",
-                    "nodeType": "Identifier",
-                    "overloadedDeclarations": [],
-                    "referencedDeclaration": 23930,
-                    "src": "1159:7:13",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_struct$_StructTwo_$23924_storage",
-                      "typeString": "struct BytecodeExample.StructTwo storage ref"
-                    }
-                  },
-                  "functionReturnParameters": 23985,
-                  "id": 23987,
-                  "nodeType": "Return",
-                  "src": "1152:14:13"
-                }
-              ]
-            },
-            "functionSelector": "1b78187d",
-            "implemented": true,
-            "kind": "function",
-            "modifiers": [],
-            "name": "get_current",
-            "nameLocation": "1089:11:13",
-            "parameters": {
-              "id": 23981,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "1100:2:13"
-            },
-            "returnParameters": {
-              "id": 23985,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 23984,
-                  "mutability": "mutable",
-                  "name": "",
-                  "nameLocation": "-1:-1:-1",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 23989,
-                  "src": "1124:16:13",
-                  "stateVariable": false,
-                  "storageLocation": "memory",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_struct$_StructTwo_$23924_memory_ptr",
-                    "typeString": "struct BytecodeExample.StructTwo"
-                  },
-                  "typeName": {
-                    "id": 23983,
-                    "nodeType": "UserDefinedTypeName",
-                    "pathNode": {
-                      "id": 23982,
-                      "name": "StructTwo",
-                      "nameLocations": [
-                        "1124:9:13"
-                      ],
-                      "nodeType": "IdentifierPath",
-                      "referencedDeclaration": 23924,
-                      "src": "1124:9:13"
-                    },
-                    "referencedDeclaration": 23924,
-                    "src": "1124:9:13",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_struct$_StructTwo_$23924_storage_ptr",
-                      "typeString": "struct BytecodeExample.StructTwo"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "1123:18:13"
-            },
-            "scope": 23990,
-            "stateMutability": "view",
             "virtual": false,
             "visibility": "public"
           }
@@ -1109,15 +448,16 @@
         "contractKind": "contract",
         "fullyImplemented": true,
         "linearizedBaseContracts": [
-          23990
+          29203
         ],
         "name": "BytecodeExample",
-        "nameLocation": "74:15:13",
-        "scope": 23991,
-        "usedErrors": []
+        "nameLocation": "74:15:19",
+        "scope": 29204,
+        "usedErrors": [],
+        "usedEvents": []
       }
     ],
     "license": "UNLICENSED"
   },
-  "id": 13
+  "id": 19
 }

--- a/asset/PackedEncodings.sol
+++ b/asset/PackedEncodings.sol
@@ -10,34 +10,11 @@ contract BytecodeExample {
         uint128 two;
     }
 
-    // This one we use in a dynamic array as well
-    struct StructTwo {
-        address addr;
-        bool isEnabled;
-    }
-
-    // This struct is just used directly. 
+    // This struct is just used directly.
     StructOne internal data;
-
-    // Here we create a connection between a dynamic array and a storage slot.
-    // We should be able to infer a struct type for the slot.
-    StructTwo internal current;
-    StructTwo[] public history;
 
     function set_data(uint64 one, uint128 two) public {
         data.one = one;
         data.two = two;
-    }
-
-    // Updates the current and adds the old one to the history
-    function new_current(address addr, bool isEnabled) public {
-        history.push(current);
-        current.addr = addr;
-        current.isEnabled = isEnabled;
-    }
-
-    // A getter for the current
-    function get_current() public view returns (StructTwo memory) {
-        return current;
     }
 }

--- a/asset/ReplaceMeForTesting.json
+++ b/asset/ReplaceMeForTesting.json
@@ -3,73 +3,39 @@
     {
       "inputs": [
         {
-          "internalType": "uint128",
-          "name": "key",
-          "type": "uint128"
+          "internalType": "uint64",
+          "name": "one",
+          "type": "uint64"
         },
         {
-          "internalType": "uint256",
-          "name": "value",
-          "type": "uint256"
+          "internalType": "uint128",
+          "name": "two",
+          "type": "uint128"
         }
       ],
-      "name": "add",
+      "name": "set_data",
       "outputs": [],
       "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint64",
-          "name": "number",
-          "type": "uint64"
-        }
-      ],
-      "name": "append",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "index",
-          "type": "uint256"
-        }
-      ],
-      "name": "read",
-      "outputs": [
-        {
-          "internalType": "uint64",
-          "name": "",
-          "type": "uint64"
-        }
-      ],
-      "stateMutability": "view",
       "type": "function"
     }
   ],
   "bytecode": {
-    "object": "0x608060405234801561001057600080fd5b5061022d806100206000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c80633b076df414610046578063871d7573146100b9578063ed2e5a97146100e9575b600080fd5b6100b761005436600461015f565b6001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf66004820401805460039092166008026101000a67ffffffffffffffff818102199093169390921691909102919091179055565b005b6100b76100c7366004610190565b6001600160801b03909116600090815260208181526040808320909152902055565b6100fc6100f73660046101c8565b610119565b60405167ffffffffffffffff909116815260200160405180910390f35b60006001828154811061012e5761012e6101e1565b90600052602060002090600491828204019190066008029054906101000a900467ffffffffffffffff169050919050565b60006020828403121561017157600080fd5b813567ffffffffffffffff8116811461018957600080fd5b9392505050565b600080604083850312156101a357600080fd5b82356001600160801b03811681146101ba57600080fd5b946020939093013593505050565b6000602082840312156101da57600080fd5b5035919050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212206e123127fa4e1b84a05360ff2312642e7eca667c5e4bb91600d5fadf7744889064736f6c63430008130033",
-    "sourceMap": "65:410:19:-:0;;;;;;;;;;;;;;;;;;;",
+    "object": "0x608060405234801561001057600080fd5b5060fa8061001f6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c80637487866214602d575b600080fd5b607360383660046075565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b60008060408385031215608757600080fd5b823567ffffffffffffffff81168114609e57600080fd5b915060208301356001600160801b038116811460b957600080fd5b80915050925092905056fea26469706673582212201cf953c228d34054f8000f54f4343aa616b0f913e8b736e93bc9783f73a23b9364736f6c63430008150033",
+    "sourceMap": "65:1152:19:-:0;;;;;;;;;;;;;;;;;;;",
     "linkReferences": {}
   },
   "deployedBytecode": {
-    "object": "0x608060405234801561001057600080fd5b50600436106100415760003560e01c80633b076df414610046578063871d7573146100b9578063ed2e5a97146100e9575b600080fd5b6100b761005436600461015f565b6001805480820182556000919091527fb10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf66004820401805460039092166008026101000a67ffffffffffffffff818102199093169390921691909102919091179055565b005b6100b76100c7366004610190565b6001600160801b03909116600090815260208181526040808320909152902055565b6100fc6100f73660046101c8565b610119565b60405167ffffffffffffffff909116815260200160405180910390f35b60006001828154811061012e5761012e6101e1565b90600052602060002090600491828204019190066008029054906101000a900467ffffffffffffffff169050919050565b60006020828403121561017157600080fd5b813567ffffffffffffffff8116811461018957600080fd5b9392505050565b600080604083850312156101a357600080fd5b82356001600160801b03811681146101ba57600080fd5b946020939093013593505050565b6000602082840312156101da57600080fd5b5035919050565b634e487b7160e01b600052603260045260246000fdfea26469706673582212206e123127fa4e1b84a05360ff2312642e7eca667c5e4bb91600d5fadf7744889064736f6c63430008130033",
-    "sourceMap": "65:410:19:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;296:75;;;;;;:::i;:::-;344:7;:20;;;;;;;-1:-1:-1;344:20:19;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;296:75;;;199:91;;;;;;:::i;:::-;-1:-1:-1;;;;;257:13:19;;;:8;:13;;;;;;;;;;;:18;;;;;:26;199:91;377:96;;;;;;:::i;:::-;;:::i;:::-;;;1036:18:21;1024:31;;;1006:50;;994:2;979:18;377:96:19;;;;;;;;427:6;452:7;460:5;452:14;;;;;;;;:::i;:::-;;;;;;;;;;;;;;;;;;;;;;;;;;;;445:21;;377:96;;;:::o;14:284:21:-;72:6;125:2;113:9;104:7;100:23;96:32;93:52;;;141:1;138;131:12;93:52;180:9;167:23;230:18;223:5;219:30;212:5;209:41;199:69;;264:1;261;254:12;199:69;287:5;14:284;-1:-1:-1;;;14:284:21:o;303:369::-;371:6;379;432:2;420:9;411:7;407:23;403:32;400:52;;;448:1;445;438:12;400:52;487:9;474:23;-1:-1:-1;;;;;530:5:21;526:46;519:5;516:57;506:85;;587:1;584;577:12;506:85;610:5;662:2;647:18;;;;634:32;;-1:-1:-1;;;303:369:21:o;677:180::-;736:6;789:2;777:9;768:7;764:23;760:32;757:52;;;805:1;802;795:12;757:52;-1:-1:-1;828:23:21;;677:180;-1:-1:-1;677:180:21:o;1067:127::-;1128:10;1123:3;1119:20;1116:1;1109:31;1159:4;1156:1;1149:15;1183:4;1180:1;1173:15",
+    "object": "0x6080604052348015600f57600080fd5b506004361060285760003560e01c80637487866214602d575b600080fd5b607360383660046075565b600080546001600160801b0390921668010000000000000000026001600160c01b031990921667ffffffffffffffff90931692909217179055565b005b60008060408385031215608757600080fd5b823567ffffffffffffffff81168114609e57600080fd5b915060208301356001600160801b038116811460b957600080fd5b80915050925092905056fea26469706673582212201cf953c228d34054f8000f54f4343aa616b0f913e8b736e93bc9783f73a23b9364736f6c63430008150033",
+    "sourceMap": "65:1152:19:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;722:105;;;;;;:::i;:::-;782:4;:14;;-1:-1:-1;;;;;806:14:19;;;;;-1:-1:-1;;;;;;806:14:19;;;782;;;;806;;;;;;;722:105;;;14:481:21;81:6;89;142:2;130:9;121:7;117:23;113:32;110:52;;;158:1;155;148:12;110:52;197:9;184:23;247:18;240:5;236:30;229:5;226:41;216:69;;281:1;278;271:12;216:69;304:5;-1:-1:-1;361:2:21;346:18;;333:32;-1:-1:-1;;;;;396:48:21;;384:61;;374:89;;459:1;456;449:12;374:89;482:7;472:17;;;14:481;;;;;:::o",
     "linkReferences": {}
   },
   "methodIdentifiers": {
-    "add(uint128,uint256)": "871d7573",
-    "append(uint64)": "3b076df4",
-    "read(uint256)": "ed2e5a97"
+    "set_data(uint64,uint128)": "74878662"
   },
-  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.19+commit.7dd6d404\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint128\",\"name\":\"key\",\"type\":\"uint128\"},{\"internalType\":\"uint256\",\"name\":\"value\",\"type\":\"uint256\"}],\"name\":\"add\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"number\",\"type\":\"uint64\"}],\"name\":\"append\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"index\",\"type\":\"uint256\"}],\"name\":\"read\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/BytecodeExample.sol\":\"BytecodeExample\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":ds-test/=lib/forge-std/lib/ds-test/src/\",\":forge-std/=lib/forge-std/src/\"]},\"sources\":{\"src/BytecodeExample.sol\":{\"keccak256\":\"0x2adb29206e84ee9eea1c3477f5e4b88804ea0e08287ce7c34d9e71a45b73c04f\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://f01c75aaeedab5e22c8cd6439da0e844e0c7deeea6af22464f25f801e15df55e\",\"dweb:/ipfs/QmVR6apvqZxt6qpcCGHxe6HKBS9XDuMCJdZNvrduPpVy7J\"]}},\"version\":1}",
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.21+commit.d9974bed\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint64\",\"name\":\"one\",\"type\":\"uint64\"},{\"internalType\":\"uint128\",\"name\":\"two\",\"type\":\"uint128\"}],\"name\":\"set_data\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/BytecodeExample.sol\":\"BytecodeExample\"},\"evmVersion\":\"paris\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":ds-test/=lib/forge-std/lib/ds-test/src/\",\":forge-std/=lib/forge-std/src/\"]},\"sources\":{\"src/BytecodeExample.sol\":{\"keccak256\":\"0x8829bfc0f0a1a82518ce2b2cc7f47806d5bb5682f26cebe685543b71b2198af3\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://2d8520ef8f53ac582e8833b1ca18fd26d3acb33095fb9ad4e7a0eb9401270491\",\"dweb:/ipfs/QmQjGHJdFFBeFBkubXHzBH6w4rvDah7atjPruNFRqt6srv\"]}},\"version\":1}",
   "metadata": {
     "compiler": {
-      "version": "0.8.19+commit.7dd6d404"
+      "version": "0.8.21+commit.d9974bed"
     },
     "language": "Solidity",
     "output": {
@@ -77,50 +43,19 @@
         {
           "inputs": [
             {
-              "internalType": "uint128",
-              "name": "key",
-              "type": "uint128"
+              "internalType": "uint64",
+              "name": "one",
+              "type": "uint64"
             },
             {
-              "internalType": "uint256",
-              "name": "value",
-              "type": "uint256"
+              "internalType": "uint128",
+              "name": "two",
+              "type": "uint128"
             }
           ],
           "stateMutability": "nonpayable",
           "type": "function",
-          "name": "add"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint64",
-              "name": "number",
-              "type": "uint64"
-            }
-          ],
-          "stateMutability": "nonpayable",
-          "type": "function",
-          "name": "append"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "uint256",
-              "name": "index",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function",
-          "name": "read",
-          "outputs": [
-            {
-              "internalType": "uint64",
-              "name": "",
-              "type": "uint64"
-            }
-          ]
+          "name": "set_data"
         }
       ],
       "devdoc": {
@@ -136,8 +71,8 @@
     },
     "settings": {
       "remappings": [
-        ":ds-test/=lib/forge-std/lib/ds-test/src/",
-        ":forge-std/=lib/forge-std/src/"
+        "ds-test/=lib/forge-std/lib/ds-test/src/",
+        "forge-std/=lib/forge-std/src/"
       ],
       "optimizer": {
         "enabled": true,
@@ -153,10 +88,10 @@
     },
     "sources": {
       "src/BytecodeExample.sol": {
-        "keccak256": "0x2adb29206e84ee9eea1c3477f5e4b88804ea0e08287ce7c34d9e71a45b73c04f",
+        "keccak256": "0x8829bfc0f0a1a82518ce2b2cc7f47806d5bb5682f26cebe685543b71b2198af3",
         "urls": [
-          "bzz-raw://f01c75aaeedab5e22c8cd6439da0e844e0c7deeea6af22464f25f801e15df55e",
-          "dweb:/ipfs/QmVR6apvqZxt6qpcCGHxe6HKBS9XDuMCJdZNvrduPpVy7J"
+          "bzz-raw://2d8520ef8f53ac582e8833b1ca18fd26d3acb33095fb9ad4e7a0eb9401270491",
+          "dweb:/ipfs/QmQjGHJdFFBeFBkubXHzBH6w4rvDah7atjPruNFRqt6srv"
         ],
         "license": "UNLICENSED"
       }
@@ -165,14 +100,14 @@
   },
   "ast": {
     "absolutePath": "src/BytecodeExample.sol",
-    "id": 29225,
+    "id": 29204,
     "exportedSymbols": {
       "BytecodeExample": [
-        29224
+        29203
       ]
     },
     "nodeType": "SourceUnit",
-    "src": "39:437:19",
+    "src": "39:1179:19",
     "nodes": [
       {
         "id": 29174,
@@ -187,246 +122,292 @@
         ]
       },
       {
-        "id": 29224,
+        "id": 29203,
         "nodeType": "ContractDefinition",
-        "src": "65:410:19",
+        "src": "65:1152:19",
         "nodes": [
           {
-            "id": 29180,
-            "nodeType": "VariableDeclaration",
-            "src": "96:65:19",
+            "id": 29179,
+            "nodeType": "StructDefinition",
+            "src": "228:65:19",
             "nodes": [],
-            "constant": false,
-            "mutability": "mutable",
-            "name": "mappings",
-            "nameLocation": "153:8:19",
-            "scope": 29224,
-            "stateVariable": true,
-            "storageLocation": "default",
-            "typeDescriptions": {
-              "typeIdentifier": "t_mapping$_t_uint128_$_t_mapping$_t_uint128_$_t_uint256_$_$",
-              "typeString": "mapping(uint128 => mapping(uint128 => uint256))"
-            },
-            "typeName": {
-              "id": 29179,
-              "keyName": "",
-              "keyNameLocation": "-1:-1:-1",
-              "keyType": {
-                "id": 29175,
-                "name": "uint128",
-                "nodeType": "ElementaryTypeName",
-                "src": "104:7:19",
+            "canonicalName": "BytecodeExample.StructOne",
+            "members": [
+              {
+                "constant": false,
+                "id": 29176,
+                "mutability": "mutable",
+                "name": "one",
+                "nameLocation": "262:3:19",
+                "nodeType": "VariableDeclaration",
+                "scope": 29179,
+                "src": "255:10:19",
+                "stateVariable": false,
+                "storageLocation": "default",
+                "typeDescriptions": {
+                  "typeIdentifier": "t_uint64",
+                  "typeString": "uint64"
+                },
+                "typeName": {
+                  "id": 29175,
+                  "name": "uint64",
+                  "nodeType": "ElementaryTypeName",
+                  "src": "255:6:19",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
+                  }
+                },
+                "visibility": "internal"
+              },
+              {
+                "constant": false,
+                "id": 29178,
+                "mutability": "mutable",
+                "name": "two",
+                "nameLocation": "283:3:19",
+                "nodeType": "VariableDeclaration",
+                "scope": 29179,
+                "src": "275:11:19",
+                "stateVariable": false,
+                "storageLocation": "default",
                 "typeDescriptions": {
                   "typeIdentifier": "t_uint128",
                   "typeString": "uint128"
-                }
-              },
-              "nodeType": "Mapping",
-              "src": "96:47:19",
-              "typeDescriptions": {
-                "typeIdentifier": "t_mapping$_t_uint128_$_t_mapping$_t_uint128_$_t_uint256_$_$",
-                "typeString": "mapping(uint128 => mapping(uint128 => uint256))"
-              },
-              "valueName": "",
-              "valueNameLocation": "-1:-1:-1",
-              "valueType": {
-                "id": 29178,
-                "keyName": "",
-                "keyNameLocation": "-1:-1:-1",
-                "keyType": {
-                  "id": 29176,
+                },
+                "typeName": {
+                  "id": 29177,
                   "name": "uint128",
                   "nodeType": "ElementaryTypeName",
-                  "src": "123:7:19",
+                  "src": "275:7:19",
                   "typeDescriptions": {
                     "typeIdentifier": "t_uint128",
                     "typeString": "uint128"
                   }
                 },
-                "nodeType": "Mapping",
-                "src": "115:27:19",
-                "typeDescriptions": {
-                  "typeIdentifier": "t_mapping$_t_uint128_$_t_uint256_$",
-                  "typeString": "mapping(uint128 => uint256)"
-                },
-                "valueName": "",
-                "valueNameLocation": "-1:-1:-1",
-                "valueType": {
-                  "id": 29177,
-                  "name": "uint256",
-                  "nodeType": "ElementaryTypeName",
-                  "src": "134:7:19",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  }
-                }
+                "visibility": "internal"
               }
-            },
-            "visibility": "internal"
+            ],
+            "name": "StructOne",
+            "nameLocation": "235:9:19",
+            "scope": 29203,
+            "visibility": "public"
           },
           {
-            "id": 29183,
+            "id": 29182,
             "nodeType": "VariableDeclaration",
-            "src": "167:25:19",
+            "src": "480:23:19",
             "nodes": [],
             "constant": false,
             "mutability": "mutable",
-            "name": "numbers",
-            "nameLocation": "185:7:19",
-            "scope": 29224,
+            "name": "data",
+            "nameLocation": "499:4:19",
+            "scope": 29203,
             "stateVariable": true,
             "storageLocation": "default",
             "typeDescriptions": {
-              "typeIdentifier": "t_array$_t_uint64_$dyn_storage",
-              "typeString": "uint64[]"
+              "typeIdentifier": "t_struct$_StructOne_$29179_storage",
+              "typeString": "struct BytecodeExample.StructOne"
             },
             "typeName": {
-              "baseType": {
-                "id": 29181,
-                "name": "uint64",
-                "nodeType": "ElementaryTypeName",
-                "src": "167:6:19",
-                "typeDescriptions": {
-                  "typeIdentifier": "t_uint64",
-                  "typeString": "uint64"
-                }
+              "id": 29181,
+              "nodeType": "UserDefinedTypeName",
+              "pathNode": {
+                "id": 29180,
+                "name": "StructOne",
+                "nameLocations": [
+                  "480:9:19"
+                ],
+                "nodeType": "IdentifierPath",
+                "referencedDeclaration": 29179,
+                "src": "480:9:19"
               },
-              "id": 29182,
-              "nodeType": "ArrayTypeName",
-              "src": "167:8:19",
+              "referencedDeclaration": 29179,
+              "src": "480:9:19",
               "typeDescriptions": {
-                "typeIdentifier": "t_array$_t_uint64_$dyn_storage_ptr",
-                "typeString": "uint64[]"
+                "typeIdentifier": "t_struct$_StructOne_$29179_storage_ptr",
+                "typeString": "struct BytecodeExample.StructOne"
               }
             },
             "visibility": "internal"
           },
           {
-            "id": 29199,
+            "id": 29202,
             "nodeType": "FunctionDefinition",
-            "src": "199:91:19",
+            "src": "722:105:19",
             "nodes": [],
             "body": {
-              "id": 29198,
+              "id": 29201,
               "nodeType": "Block",
-              "src": "247:43:19",
+              "src": "772:55:19",
               "nodes": [],
               "statements": [
                 {
                   "expression": {
-                    "id": 29196,
+                    "id": 29193,
                     "isConstant": false,
                     "isLValue": false,
                     "isPure": false,
                     "lValueRequested": false,
                     "leftHandSide": {
-                      "baseExpression": {
-                        "baseExpression": {
-                          "id": 29190,
-                          "name": "mappings",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 29180,
-                          "src": "257:8:19",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_mapping$_t_uint128_$_t_mapping$_t_uint128_$_t_uint256_$_$",
-                            "typeString": "mapping(uint128 => mapping(uint128 => uint256))"
-                          }
-                        },
-                        "id": 29193,
-                        "indexExpression": {
-                          "id": 29191,
-                          "name": "key",
-                          "nodeType": "Identifier",
-                          "overloadedDeclarations": [],
-                          "referencedDeclaration": 29185,
-                          "src": "266:3:19",
-                          "typeDescriptions": {
-                            "typeIdentifier": "t_uint128",
-                            "typeString": "uint128"
-                          }
-                        },
-                        "isConstant": false,
-                        "isLValue": true,
-                        "isPure": false,
-                        "lValueRequested": false,
-                        "nodeType": "IndexAccess",
-                        "src": "257:13:19",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_mapping$_t_uint128_$_t_uint256_$",
-                          "typeString": "mapping(uint128 => uint256)"
-                        }
-                      },
-                      "id": 29194,
-                      "indexExpression": {
-                        "id": 29192,
-                        "name": "key",
+                      "expression": {
+                        "id": 29189,
+                        "name": "data",
                         "nodeType": "Identifier",
                         "overloadedDeclarations": [],
-                        "referencedDeclaration": 29185,
-                        "src": "271:3:19",
+                        "referencedDeclaration": 29182,
+                        "src": "782:4:19",
                         "typeDescriptions": {
-                          "typeIdentifier": "t_uint128",
-                          "typeString": "uint128"
+                          "typeIdentifier": "t_struct$_StructOne_$29179_storage",
+                          "typeString": "struct BytecodeExample.StructOne storage ref"
                         }
                       },
+                      "id": 29191,
                       "isConstant": false,
                       "isLValue": true,
                       "isPure": false,
                       "lValueRequested": true,
-                      "nodeType": "IndexAccess",
-                      "src": "257:18:19",
+                      "memberLocation": "787:3:19",
+                      "memberName": "one",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 29176,
+                      "src": "782:8:19",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_uint256",
-                        "typeString": "uint256"
+                        "typeIdentifier": "t_uint64",
+                        "typeString": "uint64"
                       }
                     },
                     "nodeType": "Assignment",
                     "operator": "=",
                     "rightHandSide": {
-                      "id": 29195,
-                      "name": "value",
+                      "id": 29192,
+                      "name": "one",
                       "nodeType": "Identifier",
                       "overloadedDeclarations": [],
-                      "referencedDeclaration": 29187,
-                      "src": "278:5:19",
+                      "referencedDeclaration": 29184,
+                      "src": "793:3:19",
                       "typeDescriptions": {
-                        "typeIdentifier": "t_uint256",
-                        "typeString": "uint256"
+                        "typeIdentifier": "t_uint64",
+                        "typeString": "uint64"
                       }
                     },
-                    "src": "257:26:19",
+                    "src": "782:14:19",
                     "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
                     }
                   },
-                  "id": 29197,
+                  "id": 29194,
                   "nodeType": "ExpressionStatement",
-                  "src": "257:26:19"
+                  "src": "782:14:19"
+                },
+                {
+                  "expression": {
+                    "id": 29199,
+                    "isConstant": false,
+                    "isLValue": false,
+                    "isPure": false,
+                    "lValueRequested": false,
+                    "leftHandSide": {
+                      "expression": {
+                        "id": 29195,
+                        "name": "data",
+                        "nodeType": "Identifier",
+                        "overloadedDeclarations": [],
+                        "referencedDeclaration": 29182,
+                        "src": "806:4:19",
+                        "typeDescriptions": {
+                          "typeIdentifier": "t_struct$_StructOne_$29179_storage",
+                          "typeString": "struct BytecodeExample.StructOne storage ref"
+                        }
+                      },
+                      "id": 29197,
+                      "isConstant": false,
+                      "isLValue": true,
+                      "isPure": false,
+                      "lValueRequested": true,
+                      "memberLocation": "811:3:19",
+                      "memberName": "two",
+                      "nodeType": "MemberAccess",
+                      "referencedDeclaration": 29178,
+                      "src": "806:8:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint128",
+                        "typeString": "uint128"
+                      }
+                    },
+                    "nodeType": "Assignment",
+                    "operator": "=",
+                    "rightHandSide": {
+                      "id": 29198,
+                      "name": "two",
+                      "nodeType": "Identifier",
+                      "overloadedDeclarations": [],
+                      "referencedDeclaration": 29186,
+                      "src": "817:3:19",
+                      "typeDescriptions": {
+                        "typeIdentifier": "t_uint128",
+                        "typeString": "uint128"
+                      }
+                    },
+                    "src": "806:14:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint128",
+                      "typeString": "uint128"
+                    }
+                  },
+                  "id": 29200,
+                  "nodeType": "ExpressionStatement",
+                  "src": "806:14:19"
                 }
               ]
             },
-            "functionSelector": "871d7573",
+            "functionSelector": "74878662",
             "implemented": true,
             "kind": "function",
             "modifiers": [],
-            "name": "add",
-            "nameLocation": "208:3:19",
+            "name": "set_data",
+            "nameLocation": "731:8:19",
             "parameters": {
-              "id": 29188,
+              "id": 29187,
               "nodeType": "ParameterList",
               "parameters": [
                 {
                   "constant": false,
-                  "id": 29185,
+                  "id": 29184,
                   "mutability": "mutable",
-                  "name": "key",
-                  "nameLocation": "220:3:19",
+                  "name": "one",
+                  "nameLocation": "747:3:19",
                   "nodeType": "VariableDeclaration",
-                  "scope": 29199,
-                  "src": "212:11:19",
+                  "scope": 29202,
+                  "src": "740:10:19",
+                  "stateVariable": false,
+                  "storageLocation": "default",
+                  "typeDescriptions": {
+                    "typeIdentifier": "t_uint64",
+                    "typeString": "uint64"
+                  },
+                  "typeName": {
+                    "id": 29183,
+                    "name": "uint64",
+                    "nodeType": "ElementaryTypeName",
+                    "src": "740:6:19",
+                    "typeDescriptions": {
+                      "typeIdentifier": "t_uint64",
+                      "typeString": "uint64"
+                    }
+                  },
+                  "visibility": "internal"
+                },
+                {
+                  "constant": false,
+                  "id": 29186,
+                  "mutability": "mutable",
+                  "name": "two",
+                  "nameLocation": "760:3:19",
+                  "nodeType": "VariableDeclaration",
+                  "scope": 29202,
+                  "src": "752:11:19",
                   "stateVariable": false,
                   "storageLocation": "default",
                   "typeDescriptions": {
@@ -434,323 +415,28 @@
                     "typeString": "uint128"
                   },
                   "typeName": {
-                    "id": 29184,
+                    "id": 29185,
                     "name": "uint128",
                     "nodeType": "ElementaryTypeName",
-                    "src": "212:7:19",
+                    "src": "752:7:19",
                     "typeDescriptions": {
                       "typeIdentifier": "t_uint128",
                       "typeString": "uint128"
                     }
                   },
                   "visibility": "internal"
-                },
-                {
-                  "constant": false,
-                  "id": 29187,
-                  "mutability": "mutable",
-                  "name": "value",
-                  "nameLocation": "233:5:19",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 29199,
-                  "src": "225:13:19",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 29186,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "225:7:19",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
                 }
               ],
-              "src": "211:28:19"
+              "src": "739:25:19"
             },
             "returnParameters": {
-              "id": 29189,
+              "id": 29188,
               "nodeType": "ParameterList",
               "parameters": [],
-              "src": "247:0:19"
+              "src": "772:0:19"
             },
-            "scope": 29224,
+            "scope": 29203,
             "stateMutability": "nonpayable",
-            "virtual": false,
-            "visibility": "public"
-          },
-          {
-            "id": 29211,
-            "nodeType": "FunctionDefinition",
-            "src": "296:75:19",
-            "nodes": [],
-            "body": {
-              "id": 29210,
-              "nodeType": "Block",
-              "src": "334:37:19",
-              "nodes": [],
-              "statements": [
-                {
-                  "expression": {
-                    "arguments": [
-                      {
-                        "id": 29207,
-                        "name": "number",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 29201,
-                        "src": "357:6:19",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_uint64",
-                          "typeString": "uint64"
-                        }
-                      }
-                    ],
-                    "expression": {
-                      "argumentTypes": [
-                        {
-                          "typeIdentifier": "t_uint64",
-                          "typeString": "uint64"
-                        }
-                      ],
-                      "expression": {
-                        "id": 29204,
-                        "name": "numbers",
-                        "nodeType": "Identifier",
-                        "overloadedDeclarations": [],
-                        "referencedDeclaration": 29183,
-                        "src": "344:7:19",
-                        "typeDescriptions": {
-                          "typeIdentifier": "t_array$_t_uint64_$dyn_storage",
-                          "typeString": "uint64[] storage ref"
-                        }
-                      },
-                      "id": 29206,
-                      "isConstant": false,
-                      "isLValue": false,
-                      "isPure": false,
-                      "lValueRequested": false,
-                      "memberLocation": "352:4:19",
-                      "memberName": "push",
-                      "nodeType": "MemberAccess",
-                      "src": "344:12:19",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_function_arraypush_nonpayable$_t_array$_t_uint64_$dyn_storage_ptr_$_t_uint64_$returns$__$attached_to$_t_array$_t_uint64_$dyn_storage_ptr_$",
-                        "typeString": "function (uint64[] storage pointer,uint64)"
-                      }
-                    },
-                    "id": 29208,
-                    "isConstant": false,
-                    "isLValue": false,
-                    "isPure": false,
-                    "kind": "functionCall",
-                    "lValueRequested": false,
-                    "nameLocations": [],
-                    "names": [],
-                    "nodeType": "FunctionCall",
-                    "src": "344:20:19",
-                    "tryCall": false,
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_tuple$__$",
-                      "typeString": "tuple()"
-                    }
-                  },
-                  "id": 29209,
-                  "nodeType": "ExpressionStatement",
-                  "src": "344:20:19"
-                }
-              ]
-            },
-            "functionSelector": "3b076df4",
-            "implemented": true,
-            "kind": "function",
-            "modifiers": [],
-            "name": "append",
-            "nameLocation": "305:6:19",
-            "parameters": {
-              "id": 29202,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 29201,
-                  "mutability": "mutable",
-                  "name": "number",
-                  "nameLocation": "319:6:19",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 29211,
-                  "src": "312:13:19",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 29200,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "312:6:19",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "311:15:19"
-            },
-            "returnParameters": {
-              "id": 29203,
-              "nodeType": "ParameterList",
-              "parameters": [],
-              "src": "334:0:19"
-            },
-            "scope": 29224,
-            "stateMutability": "nonpayable",
-            "virtual": false,
-            "visibility": "public"
-          },
-          {
-            "id": 29223,
-            "nodeType": "FunctionDefinition",
-            "src": "377:96:19",
-            "nodes": [],
-            "body": {
-              "id": 29222,
-              "nodeType": "Block",
-              "src": "435:38:19",
-              "nodes": [],
-              "statements": [
-                {
-                  "expression": {
-                    "baseExpression": {
-                      "id": 29218,
-                      "name": "numbers",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 29183,
-                      "src": "452:7:19",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_array$_t_uint64_$dyn_storage",
-                        "typeString": "uint64[] storage ref"
-                      }
-                    },
-                    "id": 29220,
-                    "indexExpression": {
-                      "id": 29219,
-                      "name": "index",
-                      "nodeType": "Identifier",
-                      "overloadedDeclarations": [],
-                      "referencedDeclaration": 29213,
-                      "src": "460:5:19",
-                      "typeDescriptions": {
-                        "typeIdentifier": "t_uint256",
-                        "typeString": "uint256"
-                      }
-                    },
-                    "isConstant": false,
-                    "isLValue": true,
-                    "isPure": false,
-                    "lValueRequested": false,
-                    "nodeType": "IndexAccess",
-                    "src": "452:14:19",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "functionReturnParameters": 29217,
-                  "id": 29221,
-                  "nodeType": "Return",
-                  "src": "445:21:19"
-                }
-              ]
-            },
-            "functionSelector": "ed2e5a97",
-            "implemented": true,
-            "kind": "function",
-            "modifiers": [],
-            "name": "read",
-            "nameLocation": "386:4:19",
-            "parameters": {
-              "id": 29214,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 29213,
-                  "mutability": "mutable",
-                  "name": "index",
-                  "nameLocation": "399:5:19",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 29223,
-                  "src": "391:13:19",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint256",
-                    "typeString": "uint256"
-                  },
-                  "typeName": {
-                    "id": 29212,
-                    "name": "uint256",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "391:7:19",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint256",
-                      "typeString": "uint256"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "390:15:19"
-            },
-            "returnParameters": {
-              "id": 29217,
-              "nodeType": "ParameterList",
-              "parameters": [
-                {
-                  "constant": false,
-                  "id": 29216,
-                  "mutability": "mutable",
-                  "name": "",
-                  "nameLocation": "-1:-1:-1",
-                  "nodeType": "VariableDeclaration",
-                  "scope": 29223,
-                  "src": "427:6:19",
-                  "stateVariable": false,
-                  "storageLocation": "default",
-                  "typeDescriptions": {
-                    "typeIdentifier": "t_uint64",
-                    "typeString": "uint64"
-                  },
-                  "typeName": {
-                    "id": 29215,
-                    "name": "uint64",
-                    "nodeType": "ElementaryTypeName",
-                    "src": "427:6:19",
-                    "typeDescriptions": {
-                      "typeIdentifier": "t_uint64",
-                      "typeString": "uint64"
-                    }
-                  },
-                  "visibility": "internal"
-                }
-              ],
-              "src": "426:8:19"
-            },
-            "scope": 29224,
-            "stateMutability": "view",
             "virtual": false,
             "visibility": "public"
           }
@@ -762,12 +448,13 @@
         "contractKind": "contract",
         "fullyImplemented": true,
         "linearizedBaseContracts": [
-          29224
+          29203
         ],
         "name": "BytecodeExample",
         "nameLocation": "74:15:19",
-        "scope": 29225,
-        "usedErrors": []
+        "scope": 29204,
+        "usedErrors": [],
+        "usedEvents": []
       }
     ],
     "license": "UNLICENSED"

--- a/asset/ReplaceMeForTesting.sol
+++ b/asset/ReplaceMeForTesting.sol
@@ -2,18 +2,42 @@
 pragma solidity ^0.8.13;
 
 contract BytecodeExample {
-    mapping(uint128 => mapping(uint128 => uint256)) internal mappings;
-    uint64[] internal numbers;
 
-    function add(uint128 key, uint256 value) public {
-        mappings[key][key] = value;
+    // This one is only used in a storage slot, so should be indistinguishable
+    // from a packed encoding (done so we force it)
+    struct StructOne {
+        uint64 one;
+        uint128 two;
     }
 
-    function append(uint64 number) public {
-        numbers.push(number);
+    // This one we use in a dynamic array as well
+    // struct StructTwo {
+    //     address addr;
+    //     bool isEnabled;
+    // }
+
+    // This struct is just used directly.
+    StructOne internal data;
+
+    // Here we create a connection between a dynamic array and a storage slot.
+    // We should be able to infer a struct type for the slot.
+    // StructTwo internal current;
+    // StructTwo[] public history;
+
+    function set_data(uint64 one, uint128 two) public {
+        data.one = one;
+        data.two = two;
     }
 
-    function read(uint256 index) public view returns (uint64) {
-        return numbers[index];
-    }
+    // Updates the current and adds the old one to the history
+    // function new_current(address addr, bool isEnabled) public {
+    //     history.push(current);
+    //     current.addr = addr;
+    //     current.isEnabled = isEnabled;
+    // }
+
+    // A getter for the current
+    // function get_current() public view returns (StructTwo memory) {
+    //     return current;
+    // }
 }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Getting set up with this project is pretty simple.
    git clone https://github.com/smlxlio/storage-layout-analyzer.git
    ```
 
-   If you _do_ want to contribute, we recommend cloning over SSH:
+   If you _do_ want to contribute directly to the tree, we recommend cloning over SSH:
 
    ```shell
    git clone git@github.com:smlxlio/storage-layout-analyzer.git

--- a/src/inference/lift/mod.rs
+++ b/src/inference/lift/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod dynamic_array_access;
 pub mod mapping_access;
+pub mod mul_shifted;
+pub mod packed_encoding;
 pub mod recognise_hashed_slots;
 pub mod storage_slots;
 pub mod sub_word;
@@ -21,6 +23,8 @@ use crate::{
         lift::{
             dynamic_array_access::DynamicArrayAccess,
             mapping_access::MappingAccess,
+            mul_shifted::MulShiftedValue,
+            packed_encoding::PackedEncoding,
             recognise_hashed_slots::StorageSlotHashes,
             storage_slots::StorageSlots,
             sub_word::SubWordValue,
@@ -121,6 +125,8 @@ impl Default for LiftingPasses {
             passes: vec![
                 StorageSlotHashes::new(),
                 SubWordValue::new(),
+                MulShiftedValue::new(),
+                PackedEncoding::new(),
                 MappingAccess::new(),
                 DynamicArrayAccess::new(),
                 StorageSlots::new(),

--- a/src/inference/lift/mul_shifted.rs
+++ b/src/inference/lift/mul_shifted.rs
@@ -1,0 +1,328 @@
+//! This module contains the definition of a lifting pass that looks for
+//! multiplication-based shifting of bits around within a word.
+
+use crate::{
+    inference::{lift::Lift, state::InferenceState},
+    vm::value::{known::KnownWord, BoxedVal, SVD},
+};
+
+/// This pass detects and lifts expressions that move values around inside a
+/// word through multiplicative shifts.
+///
+/// These have a form as follows:
+///
+/// ```text
+/// constant * sub_word(value, offset, size)
+///
+/// becomes
+///
+/// shifted(constant, sub_word(value, offset, size))
+/// ```
+///
+/// where:
+///
+/// - The `constant` is some power of 2.
+/// - The operands to the multiplication (`*`) may be either way around.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct MulShiftedValue;
+
+impl MulShiftedValue {
+    /// Constructs a new instance of the multiplicative shifted value lifting
+    /// pass.
+    #[must_use]
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+
+    /// Calculates which power of 2 `number` is, or returns [`None`] if `number`
+    /// is not a power of 2.
+    fn which_power_of_2(mut number: KnownWord) -> Option<usize> {
+        let two = KnownWord::from_le(2u8);
+        if number == KnownWord::from_le(1u8) {
+            Some(0)
+        } else if number % two == KnownWord::zero() {
+            let mut counter = 1;
+            while number != two {
+                counter += 1;
+                number = number / two;
+            }
+
+            Some(counter)
+        } else {
+            None
+        }
+    }
+}
+
+impl Lift for MulShiftedValue {
+    fn run(
+        &mut self,
+        value: BoxedVal,
+        _state: &InferenceState,
+    ) -> crate::error::unification::Result<BoxedVal> {
+        fn insert_multiplicative_shifts(data: &SVD) -> Option<SVD> {
+            let SVD::Multiply { left, right } = data else {
+                return None;
+            };
+
+            // We need to pull out the expected structure while accounting for the fact that
+            // the operands may be either way around.
+            let (constant, value) = match (
+                left.data.clone().constant_fold(),
+                right.data.clone().constant_fold(),
+            ) {
+                (SVD::KnownData { value }, SVD::SubWord { .. }) => (
+                    value,
+                    right.clone().transform_data(insert_multiplicative_shifts),
+                ),
+                (SVD::SubWord { .. }, SVD::KnownData { value }) => (
+                    value,
+                    left.clone().transform_data(insert_multiplicative_shifts),
+                ),
+                _ => return None,
+            };
+
+            let Some(offset) = MulShiftedValue::which_power_of_2(constant) else {
+                return None;
+            };
+
+            Some(SVD::Shifted { offset, value })
+        }
+
+        Ok(value.transform_data(insert_multiplicative_shifts))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            lift::{mul_shifted::MulShiftedValue, Lift},
+            state::InferenceState,
+        },
+        vm::value::{known::KnownWord, Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn can_calculate_power_of_two_correctly() {
+        let two = KnownWord::from_le(2u8);
+        for i in 0..256u32 {
+            let power = KnownWord::from_le(i);
+            let input = two.exp(power);
+
+            let calculated_power = MulShiftedValue::which_power_of_2(input);
+            assert_eq!(calculated_power, Some(i as usize));
+        }
+    }
+
+    #[test]
+    fn can_lift_basic_multiplicative_shifts() -> anyhow::Result<()> {
+        // Create the input data
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 64,
+            },
+        );
+        let constant =
+            SV::new_known_value(2, KnownWord::from_le(2u32.pow(16)), Provenance::Synthetic);
+        let mul_const_on_left = SV::new_synthetic(
+            3,
+            SVD::Multiply {
+                left:  constant.clone(),
+                right: sub_word.clone(),
+            },
+        );
+        let mul_const_on_right = SV::new_synthetic(
+            4,
+            SVD::Multiply {
+                left:  sub_word.clone(),
+                right: constant,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result_left = MulShiftedValue.run(mul_const_on_left, &state)?;
+        let result_right = MulShiftedValue.run(mul_const_on_right, &state)?;
+
+        // Check that the results are sane
+        match result_left.data {
+            SVD::Shifted { offset, value } => {
+                assert_eq!(offset, 16);
+                assert_eq!(value, sub_word);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+        match result_right.data {
+            SVD::Shifted { offset, value } => {
+                assert_eq!(offset, 16);
+                assert_eq!(value, sub_word);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_lift_nested_multiplicative_shifts() -> anyhow::Result<()> {
+        // Create the input data
+        let inner_value = SV::new_value(0, Provenance::Synthetic);
+        let inner_sub_word = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value:  inner_value,
+                offset: 0,
+                size:   128,
+            },
+        );
+        let constant =
+            SV::new_known_value(2, KnownWord::from_le(2u32.pow(16)), Provenance::Synthetic);
+        let inner_mul = SV::new_synthetic(
+            3,
+            SVD::Multiply {
+                left:  constant.clone(),
+                right: inner_sub_word.clone(),
+            },
+        );
+        let outer_sub_word = SV::new_synthetic(
+            4,
+            SVD::SubWord {
+                value:  inner_mul,
+                offset: 0,
+                size:   192,
+            },
+        );
+        let outer_mul = SV::new_synthetic(
+            5,
+            SVD::Multiply {
+                left:  outer_sub_word,
+                right: constant,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = MulShiftedValue.run(outer_mul, &state)?;
+
+        // Check that the result is correct
+        match result.data {
+            SVD::Shifted { offset, value } => {
+                assert_eq!(offset, 16);
+
+                match value.data {
+                    SVD::SubWord {
+                        value,
+                        offset,
+                        size,
+                    } => {
+                        assert_eq!(offset, 0);
+                        assert_eq!(size, 192);
+
+                        match value.data {
+                            SVD::Shifted { offset, value } => {
+                                assert_eq!(offset, 16);
+                                assert_eq!(value, inner_sub_word);
+                            }
+                            _ => panic!("Incorrect payload"),
+                        }
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_lift_if_operand_is_non_constant() -> anyhow::Result<()> {
+        // Create the input data
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 64,
+            },
+        );
+        let constant = SV::new_value(2, Provenance::Synthetic);
+        let mul = SV::new_synthetic(
+            3,
+            SVD::Multiply {
+                left:  constant,
+                right: sub_word,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = MulShiftedValue.run(mul.clone(), &state)?;
+
+        // Check that nothing was changed
+        assert_eq!(result, mul);
+
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_lift_if_operand_is_non_sub_word() -> anyhow::Result<()> {
+        // Create the input data
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let constant =
+            SV::new_known_value(2, KnownWord::from_le(2u32.pow(16)), Provenance::Synthetic);
+        let mul = SV::new_synthetic(
+            3,
+            SVD::Multiply {
+                left:  constant,
+                right: value,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = MulShiftedValue.run(mul.clone(), &state)?;
+
+        // Check that nothing was changed
+        assert_eq!(result, mul);
+
+        Ok(())
+    }
+
+    #[test]
+    fn does_not_lift_if_operand_is_not_power_of_two() -> anyhow::Result<()> {
+        // Create the input data
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 64,
+            },
+        );
+        let constant = SV::new_known_value(2, KnownWord::from_le(31u32), Provenance::Synthetic);
+        let mul = SV::new_synthetic(
+            3,
+            SVD::Multiply {
+                left:  constant,
+                right: sub_word,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = MulShiftedValue.run(mul.clone(), &state)?;
+
+        // Check that nothing was changed
+        assert_eq!(result, mul);
+
+        Ok(())
+    }
+}

--- a/src/inference/lift/packed_encoding.rs
+++ b/src/inference/lift/packed_encoding.rs
@@ -1,0 +1,450 @@
+//! This module contains a pass that aims to discover and lift instances of
+//! multiple types being packed into a single machine word. We call these
+//! "packed encodings" throughout the codebase.
+
+use itertools::Itertools;
+
+use crate::{
+    inference::{lift::Lift, state::InferenceState},
+    vm::value::{BoxedVal, PackedSpan, SV, SVD},
+};
+
+/// This pass detects and lifts expressions that represent the packing of
+/// multiple values into a single machine word.
+///
+/// These have a form as follows:
+///
+/// ```text
+/// s_store(slot, seg_1 | seg_2 | ... | seg_n)
+///
+/// becomes
+///
+/// s_store(slot, packed(seg_1, seg_2, ..., seg_n))
+/// ```
+///
+/// where:
+///
+/// - Each `seg_i` is one of either `shifted` or `sub_word`
+/// - All of the `seg_i` elements completely cover the EVM word without
+///   overlapping.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PackedEncoding;
+
+impl PackedEncoding {
+    /// Creates a new instance of the packed encoding discovery and lifting
+    /// pass.
+    #[must_use]
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl Lift for PackedEncoding {
+    fn run(
+        &mut self,
+        value: BoxedVal,
+        _state: &InferenceState,
+    ) -> crate::error::unification::Result<BoxedVal> {
+        /// Pulls apart nodes representing bitwise ors all at the same semantic
+        /// level, or returns [`None`] if none were found.
+        ///
+        /// The order of the returned values is arbitrary.
+        #[allow(clippy::boxed_local)] // We pass all these things around boxed
+        fn unpick_ors(data: BoxedVal) -> Option<Vec<BoxedVal>> {
+            let SVD::Or { left, right } = data.data else { return None };
+            let left_ors = unpick_ors(left.clone());
+            let right_ors = unpick_ors(right.clone());
+
+            match left_ors {
+                Some(mut l_ors) => {
+                    if let Some(r_ors) = right_ors {
+                        l_ors.extend(r_ors);
+                        Some(l_ors)
+                    } else {
+                        l_ors.push(right);
+                        Some(l_ors)
+                    }
+                }
+                None => {
+                    if let Some(mut r_ors) = right_ors {
+                        r_ors.push(left);
+                        Some(r_ors)
+                    } else {
+                        Some(vec![left, right])
+                    }
+                }
+            }
+        }
+
+        fn lift_packed_encodings(data: &SVD) -> Option<SVD> {
+            // At the top level it needs to be a storage write
+            let SVD::StorageWrite { key, value } = data else { return None };
+
+            // We then pull it apart into top-level elements, and fail out if they are not
+            // valid types for this
+            let Some(elements) = unpick_ors(value.clone()) else { return None };
+            let true = elements
+                .iter()
+                .map(|e| matches!(e.data, SVD::Shifted { .. } | SVD::SubWord { .. }))
+                .all(|r| r)
+            else {
+                return None;
+            };
+
+            // Next, we need to turn those elements into spans so that we can compute
+            // coverage of the word (by sorting elements)
+            let spans: Vec<PackedSpan> = elements
+                .into_iter()
+                .map(|e| match &e.data {
+                    SVD::SubWord { offset, size, .. } => PackedSpan::new(*offset, *size, e),
+                    SVD::Shifted { offset, value } => match &value.data {
+                        SVD::SubWord { size, .. } => PackedSpan::new(*offset, *size, e),
+                        _ => panic!("Shift of non-sub-word"),
+                    },
+                    _ => unreachable!("Element was of impossible type"),
+                })
+                .sorted_by_key(|elem| elem.offset)
+                .collect();
+
+            // To be valid, spans must not overlap
+            let mut spans_are_valid = true;
+            let mut last_position = 0;
+            for PackedSpan { offset, size, .. } in &spans {
+                spans_are_valid = spans_are_valid && last_position <= *offset;
+                last_position = offset + size;
+            }
+
+            // In order to prevent issues with inferring types for unused portions of a
+            // slot, we drop the portions that are unused. We define being unused as a span
+            // containing a sub-word that directly reads from the same storage slot that it
+            // gets written to.
+            let used_spans: Vec<_> = spans
+                .into_iter()
+                .filter(|span| match &span.value.data {
+                    SVD::SubWord { value, .. } => !matches!(
+                        &value.data,
+                        SVD::SLoad { key: inner_key, .. } if key == inner_key
+                    ),
+                    _ => true,
+                })
+                .collect();
+
+            if spans_are_valid {
+                let packed = SV::new(
+                    value.instruction_pointer,
+                    SVD::Packed {
+                        elements: used_spans,
+                    },
+                    value.provenance,
+                );
+                let store = SVD::StorageWrite {
+                    key:   key.clone(),
+                    value: packed,
+                };
+                Some(store)
+            } else {
+                None
+            }
+        }
+
+        Ok(value.transform_data(lift_packed_encodings))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            lift::{packed_encoding::PackedEncoding, Lift},
+            state::InferenceState,
+        },
+        vm::value::{PackedSpan, Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn lifts_two_element_packed_encodings() -> anyhow::Result<()> {
+        // Construct the data to work on
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word_1 = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value:  value.clone(),
+                offset: 128,
+                size:   128,
+            },
+        );
+        let sub_word_2 = SV::new_synthetic(
+            2,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 128,
+            },
+        );
+        let or = SV::new_synthetic(
+            3,
+            SVD::Or {
+                left:  sub_word_1.clone(),
+                right: sub_word_2.clone(),
+            },
+        );
+        let input_key = SV::new_value(4, Provenance::Synthetic);
+        let store = SV::new_synthetic(
+            5,
+            SVD::StorageWrite {
+                key:   input_key.clone(),
+                value: or,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = PackedEncoding.run(store, &state)?;
+
+        // Check the structure of the data
+        match result.data {
+            SVD::StorageWrite { key, value } => {
+                assert_eq!(key, input_key);
+                match value.data {
+                    SVD::Packed { elements } => {
+                        assert_eq!(elements.len(), 2);
+                        assert!(elements.contains(&PackedSpan::new(128, 128, sub_word_1)));
+                        assert!(elements.contains(&PackedSpan::new(0, 128, sub_word_2)));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn lifts_more_complex_packed_encodings() -> anyhow::Result<()> {
+        // Construct the data to work on
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word_1 = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value:  value.clone(),
+                offset: 128,
+                size:   128,
+            },
+        );
+        let sub_word_2 = SV::new_synthetic(
+            2,
+            SVD::SubWord {
+                value:  value.clone(),
+                offset: 64,
+                size:   64,
+            },
+        );
+        let sub_word_3 = SV::new_synthetic(
+            3,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 64,
+            },
+        );
+        let inner_or = SV::new_synthetic(
+            4,
+            SVD::Or {
+                left:  sub_word_1.clone(),
+                right: sub_word_2.clone(),
+            },
+        );
+        let outer_or = SV::new_synthetic(
+            5,
+            SVD::Or {
+                left:  inner_or,
+                right: sub_word_3.clone(),
+            },
+        );
+        let input_key = SV::new_value(6, Provenance::Synthetic);
+        let store = SV::new_synthetic(
+            7,
+            SVD::StorageWrite {
+                key:   input_key.clone(),
+                value: outer_or,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = PackedEncoding.run(store, &state)?;
+
+        // Check the structure of the data
+        match result.data {
+            SVD::StorageWrite { key, value } => {
+                assert_eq!(key, input_key);
+                match value.data {
+                    SVD::Packed { elements } => {
+                        assert_eq!(elements.len(), 3);
+                        assert!(elements.contains(&PackedSpan::new(128, 128, sub_word_1)));
+                        assert!(elements.contains(&PackedSpan::new(64, 64, sub_word_2)));
+                        assert!(elements.contains(&PackedSpan::new(0, 64, sub_word_3)));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn lifts_packed_encodings_with_sized_shifted_elements() -> anyhow::Result<()> {
+        // Construct the test data
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let sub_word_1 = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value:  value.clone(),
+                offset: 128,
+                size:   128,
+            },
+        );
+        let sub_word_2 = SV::new_synthetic(
+            2,
+            SVD::SubWord {
+                value:  value.clone(),
+                offset: 0,
+                size:   64,
+            },
+        );
+        let sub_word_3 = SV::new_synthetic(
+            3,
+            SVD::SubWord {
+                value,
+                offset: 0,
+                size: 64,
+            },
+        );
+        let shifted = SV::new_synthetic(
+            4,
+            SVD::Shifted {
+                offset: 64,
+                value:  sub_word_3,
+            },
+        );
+        let inner_or = SV::new_synthetic(
+            4,
+            SVD::Or {
+                left:  sub_word_1.clone(),
+                right: sub_word_2.clone(),
+            },
+        );
+        let outer_or = SV::new_synthetic(
+            5,
+            SVD::Or {
+                left:  inner_or,
+                right: shifted.clone(),
+            },
+        );
+        let input_key = SV::new_value(6, Provenance::Synthetic);
+        let store = SV::new_synthetic(
+            7,
+            SVD::StorageWrite {
+                key:   input_key.clone(),
+                value: outer_or,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = PackedEncoding.run(store, &state)?;
+
+        // Check the structure of the data
+        match result.data {
+            SVD::StorageWrite { key, value } => {
+                assert_eq!(key, input_key);
+                match value.data {
+                    SVD::Packed { elements } => {
+                        assert_eq!(elements.len(), 3);
+                        assert!(elements.contains(&PackedSpan::new(128, 128, sub_word_1)));
+                        assert!(elements.contains(&PackedSpan::new(0, 64, sub_word_2)));
+                        assert!(elements.contains(&PackedSpan::new(64, 64, shifted)));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn drops_direct_reads_from_same_slot_in_packed_encodings() -> anyhow::Result<()> {
+        // Create the expressions to be lifted
+        let input_key = SV::new_value(4, Provenance::Synthetic);
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let uninit_load = SV::new_synthetic(
+            0,
+            SVD::UnwrittenStorageValue {
+                key: input_key.clone(),
+            },
+        );
+        let s_load = SV::new_synthetic(
+            7,
+            SVD::SLoad {
+                key:   input_key.clone(),
+                value: uninit_load,
+            },
+        );
+        let sub_word_1 = SV::new_synthetic(
+            1,
+            SVD::SubWord {
+                value,
+                offset: 128,
+                size: 128,
+            },
+        );
+        let sub_word_2 = SV::new_synthetic(
+            2,
+            SVD::SubWord {
+                value:  s_load,
+                offset: 0,
+                size:   128,
+            },
+        );
+        let or = SV::new_synthetic(
+            3,
+            SVD::Or {
+                left:  sub_word_1.clone(),
+                right: sub_word_2,
+            },
+        );
+        let store = SV::new_synthetic(
+            5,
+            SVD::StorageWrite {
+                key:   input_key.clone(),
+                value: or,
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = PackedEncoding.run(store, &state)?;
+
+        // Check the structure of the data
+        match result.data {
+            SVD::StorageWrite { key, value } => {
+                assert_eq!(key, input_key);
+                match value.data {
+                    SVD::Packed { elements } => {
+                        assert_eq!(elements.len(), 1);
+                        assert!(elements.contains(&PackedSpan::new(128, 128, sub_word_1)));
+                    }
+                    _ => panic!("Invalid payload"),
+                }
+            }
+            _ => panic!("Invalid payload"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/mod.rs
+++ b/src/inference/rule/mod.rs
@@ -15,7 +15,10 @@ pub mod external_calls;
 pub mod mapping_access;
 pub mod masked_word;
 pub mod offset_size;
+pub mod packed_encoding;
+pub mod s_load_is_element_type;
 pub mod sha3;
+pub mod shifted_has_element_type;
 pub mod storage_key;
 pub mod storage_write;
 
@@ -45,7 +48,10 @@ use crate::{
             mapping_access::MappingAccessRule,
             masked_word::MaskedWordRule,
             offset_size::OffsetSizeRule,
+            packed_encoding::PackedEncodingRule,
+            s_load_is_element_type::SLoadIsElementTypeRule,
             sha3::HashRule,
+            shifted_has_element_type::ShiftedHasElementTypeRule,
             storage_key::StorageKeyRule,
             storage_write::StorageWriteRule,
         },
@@ -145,6 +151,9 @@ impl Default for InferenceRules {
         rules.add(MappingAccessRule);
         rules.add(MaskedWordRule);
         rules.add(OffsetSizeRule);
+        rules.add(PackedEncodingRule);
+        rules.add(ShiftedHasElementTypeRule);
+        rules.add(SLoadIsElementTypeRule);
         rules.add(StorageKeyRule);
         rules.add(StorageWriteRule);
 

--- a/src/inference/rule/packed_encoding.rs
+++ b/src/inference/rule/packed_encoding.rs
@@ -1,0 +1,99 @@
+//! This module contains the inference rule definition for inferring packed type
+//! encodings for values that represent packed encodings.
+
+use crate::{
+    inference::{
+        expression::{Span, TE},
+        rule::InferenceRule,
+        state::InferenceState,
+    },
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the following equations in the typing state for
+/// expressions of the following form.
+///
+/// ```text
+/// packed(elem_1, elem_2, ..., elem_n))
+///    a    b_1     b_2   ...    b_n
+/// ```
+///
+/// equating
+///
+/// - `a = packed(b_1, b_2, ..., b_n)`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PackedEncodingRule;
+
+impl InferenceRule for PackedEncodingRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut InferenceState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::Packed { elements } = &value.data else { return Ok(()) };
+
+        // Construct the inference from this input
+        let element_spans: Vec<Span> = elements
+            .iter()
+            .map(|span| Span::new(state.var_unchecked(&span.value), span.offset, span.size))
+            .collect();
+        let packed_type = TE::packed_of(element_spans);
+
+        // Actually infer the type
+        state.infer_for(value, packed_type);
+
+        // All is well, so we return
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::{Span, TE},
+            rule::{packed_encoding::PackedEncodingRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{PackedSpan, Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_expressions_in_typing_state() -> anyhow::Result<()> {
+        // Create the expressions to be typed
+        let span_1_value = SV::new_value(0, Provenance::Synthetic);
+        let span_2_value = SV::new_value(1, Provenance::Synthetic);
+        let span_3_value = SV::new_value(2, Provenance::Synthetic);
+        let packed = SV::new_synthetic(
+            3,
+            SVD::Packed {
+                elements: vec![
+                    PackedSpan::new(0, 64, span_1_value.clone()),
+                    PackedSpan::new(128, 32, span_2_value.clone()),
+                    PackedSpan::new(192, 16, span_3_value.clone()),
+                ],
+            },
+        );
+
+        // Register these in the typing state
+        let mut state = InferenceState::empty();
+        let [span_1_tv, span_2_tv, span_3_tv, packed_tv] =
+            state.register_many([span_1_value, span_2_value, span_3_value, packed.clone()]);
+
+        // Run the rule and check things make sense
+        PackedEncodingRule.infer(&packed, &mut state)?;
+
+        assert!(state.inferences(span_1_tv).is_empty());
+        assert!(state.inferences(span_2_tv).is_empty());
+        assert!(state.inferences(span_3_tv).is_empty());
+
+        assert_eq!(state.inferences(packed_tv).len(), 1);
+        assert!(state.inferences(packed_tv).contains(&TE::packed_of(vec![
+            Span::new(span_1_tv, 0, 64),
+            Span::new(span_2_tv, 128, 32),
+            Span::new(span_3_tv, 192, 16),
+        ])));
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/s_load_is_element_type.rs
+++ b/src/inference/rule/s_load_is_element_type.rs
@@ -1,0 +1,84 @@
+//! This module contains an inference rule that equates every `SLoad` with the
+//! type of its element.
+
+use crate::{
+    inference::{expression::TE, rule::InferenceRule, state::InferenceState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the following equations in the typing state for
+/// expressions of the following form.
+///
+/// ```text
+/// s_load(key, value)
+///    a    b     c
+/// ```
+///
+/// equating
+///
+/// - `a = c`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SLoadIsElementTypeRule;
+
+impl InferenceRule for SLoadIsElementTypeRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut InferenceState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::SLoad {
+            value: inner_value, ..
+        } = &value.data
+        else {
+            return Ok(());
+        };
+
+        let inner_value_tv = state.var_unchecked(inner_value);
+        state.infer_for(value, TE::eq(inner_value_tv));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{s_load_is_element_type::SLoadIsElementTypeRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_in_state() -> anyhow::Result<()> {
+        // Create the expressions to be typed
+        let key = SV::new_value(0, Provenance::Synthetic);
+        let value = SV::new_value(1, Provenance::Synthetic);
+        let s_load = SV::new_synthetic(
+            2,
+            SVD::SLoad {
+                key:   key.clone(),
+                value: value.clone(),
+            },
+        );
+
+        // Register these in the state
+        let mut state = InferenceState::empty();
+        let [key_ty, value_ty, s_load_ty] = state.register_many([key, value, s_load.clone()]);
+
+        // Run the inference rule and check things make sense
+        SLoadIsElementTypeRule.infer(&s_load, &mut state)?;
+
+        assert!(state.inferences(key_ty).is_empty());
+
+        assert_eq!(state.inferences(value_ty).len(), 1);
+        assert!(state.inferences(value_ty).contains(&TE::eq(s_load_ty)));
+
+        assert_eq!(state.inferences(s_load_ty).len(), 1);
+        assert!(state.inferences(s_load_ty).contains(&TE::eq(value_ty)));
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/shifted_has_element_type.rs
+++ b/src/inference/rule/shifted_has_element_type.rs
@@ -1,0 +1,79 @@
+//! This module contains a rule that states that a Shifted has the type of the
+//! value that it shifts.
+
+use crate::{
+    inference::{expression::TE, rule::InferenceRule, state::InferenceState},
+    vm::value::{BoxedVal, SVD},
+};
+
+/// This rule creates the following equations in the typing state for
+/// expressions of the following form.
+///
+/// ```text
+/// shifted(offset, value)
+///    a              b
+/// ```
+///
+/// equating
+///
+/// - `a = b`
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ShiftedHasElementTypeRule;
+
+impl InferenceRule for ShiftedHasElementTypeRule {
+    fn infer(
+        &self,
+        value: &BoxedVal,
+        state: &mut InferenceState,
+    ) -> crate::error::unification::Result<()> {
+        let SVD::Shifted {
+            value: shifted_value,
+            ..
+        } = &value.data
+        else {
+            return Ok(());
+        };
+
+        let shifted_value_tv = state.var_unchecked(shifted_value);
+        state.infer_for(value, TE::eq(shifted_value_tv));
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{shifted_has_element_type::ShiftedHasElementTypeRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, SV, SVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_in_typing_state() -> anyhow::Result<()> {
+        // Create some values to operate on
+        let value = SV::new_value(0, Provenance::Synthetic);
+        let shifted = SV::new_synthetic(
+            1,
+            SVD::Shifted {
+                offset: 64,
+                value:  value.clone(),
+            },
+        );
+
+        // Register these in the state
+        let mut state = InferenceState::empty();
+        let [value_tv, shifted_tv] = state.register_many([value, shifted.clone()]);
+
+        // Run the pass and check the results
+        ShiftedHasElementTypeRule.infer(&shifted, &mut state)?;
+
+        assert!(state.inferences(value_tv).contains(&TE::eq(shifted_tv)));
+        assert!(state.inferences(shifted_tv).contains(&TE::eq(value_tv)));
+
+        Ok(())
+    }
+}

--- a/src/vm/value/known.rs
+++ b/src/vm/value/known.rs
@@ -173,13 +173,6 @@ impl KnownWord {
         KnownWord::from_le(U256::from_ne_bytes(result.to_ne_bytes()))
     }
 
-    /// Performs unsigned modulo of two known words.
-    #[must_use]
-    pub fn modulo(self, rhs: Self) -> Self {
-        // The operation takes place in native endianness, which in our case is LE
-        KnownWord::from_le(self.value % rhs.value)
-    }
-
     /// Performs signed modulo of two known words.
     #[must_use]
     pub fn signed_mod(self, rhs: Self) -> Self {
@@ -305,6 +298,15 @@ impl std::ops::Div<KnownWord> for KnownWord {
     fn div(self, rhs: KnownWord) -> Self::Output {
         // The operation takes place in native endianness, which in our case is LE
         KnownWord::from_le(self.value / rhs.value)
+    }
+}
+
+impl std::ops::Rem<KnownWord> for KnownWord {
+    type Output = KnownWord;
+
+    /// Performs unsigned modulo of two known words.
+    fn rem(self, rhs: KnownWord) -> Self::Output {
+        KnownWord::from_le(self.value % rhs.value)
     }
 }
 
@@ -583,7 +585,7 @@ mod test {
         let left = KnownWord::from_le(0x7u32);
         let right = KnownWord::from_le(0x2u32);
 
-        assert_eq!(left.modulo(right), KnownWord::from_le(0x1u32));
+        assert_eq!(left % right, KnownWord::from_le(0x1u32));
     }
 
     #[test]


### PR DESCRIPTION
# Summary

This commit implements the following features into the analyzer:

- Discovery and lifting of multiplicative shifts of values that are commonly used by solc when constructing packed encodings.
- Discovery and lifting of packed encoding structures themselves, taking the form of bitwise disjunctions of masked and shifted values.
- Care is taken in the lifting pass to ensure that segments of packed encodings that are _not used_ (are direct reads from the slot into which the packed encoding is being written) are ignored, thus ensuring we do not infer types for segments of storage slots that are not really written to.
- Loads from storage are now wrapped in `SLoad` nodes, allowing for detailed tracking of when a value was loaded from storage in the value trees.

# Details

Please carefully check my logic in all of these changes as they can be quite subtle.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
