### PR TITLE
Make the fields on `StructElement` public

### DIFF
--- a/src/inference/abi.rs
+++ b/src/inference/abi.rs
@@ -125,10 +125,10 @@ impl<'de> Deserialize<'de> for U256Wrapper {
 pub struct StructElement {
     // The offset for the element.
     pub offset: usize,
-    
+
     // The type of the element.
     #[serde(rename = "type")]
-    pub typ:    Box<AbiType>,
+    pub typ: Box<AbiType>,
 }
 
 impl StructElement {


### PR DESCRIPTION
# Summary

Make the fields on `StructElement` public

# Details

We are working on some changes to the CLI so that we can output the results in the same format as [solc](https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_storage.html#json-output) and therefore need access to the `StructElement` fields.

# Checklist

- [X] Code is formatted by Rustfmt.
- [X] Documentation has been updated if necessary.
