### PR TITLE
Fix spurious member in packed encodings

### DIFF
--- a/src/inference/lift/mul_shifted.rs
+++ b/src/inference/lift/mul_shifted.rs
@@ -36,7 +36,8 @@ impl MulShiftedValue {
 
     /// Calculates which power of 2 `number` is, or returns [`None`] if `number`
     /// is not a power of 2.
-    fn which_power_of_2(mut number: KnownWord) -> Option<usize> {
+    #[must_use]
+    pub fn which_power_of_2(mut number: KnownWord) -> Option<usize> {
         let two = KnownWord::from_le(2u8);
         if number == KnownWord::from_le(1u8) {
             Some(0)

--- a/src/inference/lift/sub_word.rs
+++ b/src/inference/lift/sub_word.rs
@@ -5,7 +5,10 @@ use itertools::Itertools;
 
 use crate::{
     constant::WORD_SIZE_BITS,
-    inference::{lift::Lift, state::InferenceState},
+    inference::{
+        lift::{mul_shifted::MulShiftedValue, Lift},
+        state::InferenceState,
+    },
     vm::value::{RuntimeBoxedVal, RSVD, SVD},
 };
 
@@ -112,6 +115,13 @@ impl SubWordValue {
                             (dividend, shift.into())
                         }
                         _ => (value, 0),
+                    }
+                }
+                RSVD::KnownData { value: divisor } => {
+                    if let Some(shift) = MulShiftedValue::which_power_of_2(*divisor) {
+                        (dividend, shift)
+                    } else {
+                        (value, 0)
                     }
                 }
                 _ => (value, 0),

--- a/src/inference/rule/mod.rs
+++ b/src/inference/rule/mod.rs
@@ -15,7 +15,7 @@ pub mod mapping_access;
 pub mod masked_word;
 pub mod offset_size;
 pub mod packed_encoding;
-pub mod s_load_is_element_type;
+pub mod s_load_is_inner_types;
 pub mod sha3;
 pub mod shifted_has_element_type;
 pub mod storage_key;
@@ -47,7 +47,7 @@ use crate::{
             masked_word::MaskedWordRule,
             offset_size::OffsetSizeRule,
             packed_encoding::PackedEncodingRule,
-            s_load_is_element_type::SLoadIsElementTypeRule,
+            s_load_is_inner_types::SLoadIsInnerTypesRule,
             sha3::HashRule,
             shifted_has_element_type::ShiftedHasElementTypeRule,
             storage_key::StorageKeyRule,
@@ -150,7 +150,7 @@ impl Default for InferenceRules {
         rules.add(OffsetSizeRule);
         rules.add(PackedEncodingRule);
         rules.add(ShiftedHasElementTypeRule);
-        rules.add(SLoadIsElementTypeRule);
+        rules.add(SLoadIsInnerTypesRule);
         rules.add(StorageKeyRule);
         rules.add(StorageWriteRule);
 

--- a/src/inference/rule/s_load_is_inner_types.rs
+++ b/src/inference/rule/s_load_is_inner_types.rs
@@ -1,5 +1,5 @@
 //! This module contains an inference rule that equates every `SLoad` with the
-//! type of its element.
+//! type of its element and its key.
 
 use crate::{
     error::unification::Result,
@@ -17,21 +17,26 @@ use crate::{
 ///
 /// equating
 ///
+/// - `a = b`
 /// - `a = c`
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
-pub struct SLoadIsElementTypeRule;
+pub struct SLoadIsInnerTypesRule;
 
-impl InferenceRule for SLoadIsElementTypeRule {
+impl InferenceRule for SLoadIsInnerTypesRule {
     fn infer(&self, value: &TCBoxedVal, state: &mut InferenceState) -> Result<()> {
         let TCSVD::SLoad {
-            value: inner_value, ..
+            value: inner_value,
+            key,
         } = &value.data
         else {
             return Ok(());
         };
 
         let inner_value_tv = state.var_unchecked(inner_value);
+        let slot_tv = state.var_unchecked(key);
+
         state.infer_for(value, TE::eq(inner_value_tv));
+        state.infer_for(value, TE::eq(slot_tv));
 
         Ok(())
     }

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -23,6 +23,9 @@ impl StorageLayout {
     }
 
     /// Gets the storage slots that make up this layout.
+    ///
+    /// These are guaranteed to be sorted in ascending order by slot index and
+    /// then offset within the slot.
     #[must_use]
     pub fn slots(&self) -> &Vec<StorageSlot> {
         &self.slots

--- a/tests/crypto_kitties.rs
+++ b/tests/crypto_kitties.rs
@@ -28,22 +28,31 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(0, 0, AbiType::Number { size: Some(160) }))
     );
 
-    // `address`, but we infer `number160`
+    // `address`, but we infer `conflict`
+    assert_eq!(layout.slots()[1].index, 1);
+    assert_eq!(layout.slots()[1].offset, 0);
+    assert!(matches!(
+        &layout.slots()[1].typ,
+        AbiType::ConflictedType { .. }
+    ));
+
+    // `address`, but we infer `conflict`
+    assert_eq!(layout.slots()[2].index, 2);
+    assert_eq!(layout.slots()[2].offset, 0);
+    assert!(matches!(
+        &layout.slots()[2].typ,
+        AbiType::ConflictedType { .. }
+    ));
+
+    // `uint32[14]`, but we infer `uint32`
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(1, 0, AbiType::Number { size: Some(160) }))
+            .contains(&StorageSlot::new(3, 0, AbiType::UInt { size: Some(32) }))
     );
 
-    // `address`, but we infer `number160`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(2, 0, AbiType::Number { size: Some(160) }))
-    );
-
-    // `uint32[14]`, but we infer `any`
-    assert!(layout.slots().contains(&StorageSlot::new(3, 0, AbiType::Any)));
+    // We don't see the rest of that array slot for now.
+    assert!(!layout.slots().iter().any(|s| s.offset == 4));
 
     // `uint256`
     assert!(
@@ -116,25 +125,36 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         _ => panic!("Incorrect type"),
     }
 
-    // `address`
-    assert!(layout.slots().contains(&StorageSlot::new(11, 0, AbiType::Address)));
+    // `address` but we infer conflict
+    assert_eq!(layout.slots()[10].index, 11);
+    assert_eq!(layout.slots()[10].offset, 0);
+    assert!(matches!(
+        &layout.slots()[10].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `address`
-    assert!(layout.slots().contains(&StorageSlot::new(12, 0, AbiType::Address)));
+    // `address` but we infer conflict
+    assert_eq!(layout.slots()[11].index, 12);
+    assert_eq!(layout.slots()[11].offset, 0);
+    assert!(matches!(
+        &layout.slots()[11].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `address` but we infer `bytes20`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        13,
-        0,
-        AbiType::Bytes { length: Some(20) }
-    )));
+    // `address` but we infer `conflict`
+    assert_eq!(layout.slots()[12].index, 13);
+    assert_eq!(layout.slots()[12].offset, 0);
+    assert!(matches!(
+        &layout.slots()[12].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `uint256` but we infer `bytes32`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        14,
-        0,
-        AbiType::Bytes { length: Some(32) }
-    )));
+    // `uint256` but we infer `uint256`
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(14, 0, AbiType::UInt { size: Some(256) }))
+    );
 
     // `uint256` but we infer `numberUnknown`
     assert!(
@@ -143,28 +163,33 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(15, 0, AbiType::Number { size: None }))
     );
 
-    // `address`
-    assert!(layout.slots().contains(&StorageSlot::new(16, 0, AbiType::Address)));
+    // `address` but we infer conflict
+    assert_eq!(layout.slots()[15].index, 16);
+    assert_eq!(layout.slots()[15].offset, 0);
+    assert!(matches!(
+        &layout.slots()[15].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `uint256` but we infer `numberUnknown`
+    // `uint256` but we infer `uintUnknown`
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(17, 0, AbiType::Number { size: None }))
+            .contains(&StorageSlot::new(17, 0, AbiType::UInt { size: None }))
     );
 
-    // `uint256` but we infer `numberUnknown`
+    // `uint256` but we infer `uintUnknown`
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(18, 0, AbiType::Number { size: None }))
+            .contains(&StorageSlot::new(18, 0, AbiType::UInt { size: None }))
     );
 
     // `address` but we infer `bytes20`
     assert!(layout.slots().contains(&StorageSlot::new(
         19,
         0,
-        AbiType::Bytes { length: Some(20) }
+        AbiType::Number { size: Some(160) }
     )));
 
     Ok(())

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -20,8 +20,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // Get the final storage layout for the input contract
     let layout = analyzer.analyze()?;
 
-    // We should see 36 entries, but we miss one
-    assert_eq!(layout.slots().len(), 35);
+    // We should see 36 entries
+    assert_eq!(layout.slots().len(), 36);
 
     // `address` but we infer `number160`
     assert!(
@@ -40,35 +40,36 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `address`
     assert!(layout.slots().contains(&StorageSlot::new(2, 0, AbiType::Address)));
 
-    // `bool` but we infer `any`
-    assert!(layout.slots().contains(&StorageSlot::new(3, 0, AbiType::Any)));
+    // `bool` but we infer `number8`
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(3, 0, AbiType::Number { size: Some(8) }))
+    );
 
-    // `string` but we infer `any[]`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        4,
-        0,
-        AbiType::DynArray {
-            tp: Box::new(AbiType::Any),
-        }
-    )));
+    // `string` but we infer `conflict`
+    assert_eq!(layout.slots()[4].index, 4);
+    assert_eq!(layout.slots()[4].offset, 0);
+    assert!(matches!(
+        &layout.slots()[4].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `string` but we infer `any[]`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        5,
-        0,
-        AbiType::DynArray {
-            tp: Box::new(AbiType::Any),
-        }
-    )));
+    // `string` but we infer `conflict`
+    assert_eq!(layout.slots()[5].index, 5);
+    assert_eq!(layout.slots()[5].offset, 0);
+    assert!(matches!(
+        &layout.slots()[5].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
-    // `string` but we infer `any[]`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        6,
-        0,
-        AbiType::DynArray {
-            tp: Box::new(AbiType::Any),
-        }
-    )));
+    // `string` but we infer `conflict`
+    assert_eq!(layout.slots()[6].index, 6);
+    assert_eq!(layout.slots()[6].offset, 0);
+    assert!(matches!(
+        &layout.slots()[6].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
     // `address` but we infer `bytes20`
     assert!(
@@ -91,24 +92,23 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(9, 0, AbiType::UInt { size: Some(256) }))
     );
 
-    // `uint256` but we infer `number256`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        10,
-        0,
-        AbiType::Number { size: Some(256) }
-    )));
+    // `uint256`
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(10, 0, AbiType::UInt { size: Some(256) }))
+    );
 
     // `uint256` but we miss it entirely
-    assert!(!layout.slots().iter().any(|slot| slot.offset == 11));
+    assert!(!layout.slots().iter().any(|slot| slot.index == 11));
 
-    // `string` but we infer `any[]`
-    assert!(layout.slots().contains(&StorageSlot::new(
-        12,
-        0,
-        AbiType::DynArray {
-            tp: Box::new(AbiType::Any),
-        }
-    )));
+    // `string` but we infer `conflict`
+    assert_eq!(layout.slots()[12].index, 12);
+    assert_eq!(layout.slots()[12].offset, 0);
+    assert!(matches!(
+        &layout.slots()[12].typ,
+        AbiType::ConflictedType { .. }
+    ));
 
     // `mapping(uint256 => struct)` but we infer `mapping(uint256 => uint256)`
     assert!(layout.slots().contains(&StorageSlot::new(

--- a/tests/sale_clock_auction.rs
+++ b/tests/sale_clock_auction.rs
@@ -19,20 +19,31 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
 
     // We should see 8 entries, but we only see 6 due to a lack of discovery of
     // fixed-length arrays, and a missing packed element
-    assert_eq!(layout.slots().len(), 6);
+    assert_eq!(layout.slots().len(), 7);
 
-    // `address`, but we infer `number160` and miss the packing
+    // `address`, but we infer `number160`
     assert!(
         layout
             .slots()
             .contains(&StorageSlot::new(0, 0, AbiType::Number { size: Some(160) }))
     );
 
-    // `address` but we infer `any`
-    assert!(layout.slots().contains(&StorageSlot::new(1, 0, AbiType::Any)));
+    // `bool`, packed
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(0, 160, AbiType::Number { size: Some(8) }))
+    );
 
-    // `uint256` but we infer `any`
-    assert!(layout.slots().contains(&StorageSlot::new(2, 0, AbiType::Any)));
+    // `address`
+    assert!(layout.slots().contains(&StorageSlot::new(1, 0, AbiType::Address)));
+
+    // `uint256` but we infer `numberUnknown`
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(2, 0, AbiType::Number { size: None }))
+    );
 
     // `mapping(uint256 => struct)` but we infer `mapping(bytes32 => address)`
     assert!(layout.slots().contains(&StorageSlot::new(
@@ -44,14 +55,18 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `bool` but we infer `any`
-    assert!(layout.slots().contains(&StorageSlot::new(4, 0, AbiType::Any)));
-
-    // `uint256` but we infer `any`
+    // `bool` but we infer `number8`
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(5, 0, AbiType::Number { size: None }))
+            .contains(&StorageSlot::new(4, 0, AbiType::Number { size: Some(8) }))
+    );
+
+    // `uint256` but we infer `uintUnknown`
+    assert!(
+        layout
+            .slots()
+            .contains(&StorageSlot::new(5, 0, AbiType::UInt { size: None }))
     );
 
     Ok(())


### PR DESCRIPTION
# Summary

The logic for writing out packed encodings (of all kinds) was incorrect at the last stage. It would sometimes insert a spurious member at offset 0 within the slot with type `Any` due to incorrect defaulting rules. This is now fixed, and we output the packed encodings correctly.

We also now infer that the type of a storage load is the same as the type of the slot being loaded from. This is correct in any well-formed program and provides strictly more information to the type checker.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
