### PR TITLE
Approximately halve memory usage

### DIFF
--- a/src/analyzer/state.rs
+++ b/src/analyzer/state.rs
@@ -86,6 +86,9 @@ pub struct InferenceReady {
 
     /// The watchdog that is monitoring the progress of the analyzer.
     pub watchdog: DynWatchdog,
+
+    /// The result of executing the virtual machine on the config.
+    pub execution_result: ExecutionResult,
 }
 impl State for InferenceReady {}
 

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -25,7 +25,7 @@ pub const MAX_MEMORY_SIZE_BITS: usize = MAX_MEMORY_SIZE_WORDS * WORD_SIZE_BITS;
 ///
 /// This is used to bound execution and ensure that we don't end up allocating
 /// too much data into memory.
-pub const MEMORY_SINGLE_OPERATION_MAX_BYTES: usize = MAX_MEMORY_SIZE_WORDS * 32 / 1_000;
+pub const DEFAULT_MEMORY_SINGLE_OPERATION_MAX_BYTES: usize = MAX_MEMORY_SIZE_WORDS * 32 / 10_000;
 
 /// The base byte value for the `PUSH` opcode, for `N > 0`.
 ///

--- a/src/opcode/control.rs
+++ b/src/opcode/control.rs
@@ -1,7 +1,6 @@
 //! Opcodes that perform control(-flow) operations on the EVM.
 
 use crate::{
-    constant::MEMORY_SINGLE_OPERATION_MAX_BYTES,
     error::{container::Locatable, execution, execution::Error},
     opcode::{util, ExecuteResult, Opcode},
     vm::{
@@ -369,7 +368,7 @@ fn store_return_data(
         // We bound the copied size to the contract size as anything bigger is going to
         // be impossible at runtime
         let actual_size: usize = value.into();
-        let size_limit = actual_size.min(MEMORY_SINGLE_OPERATION_MAX_BYTES);
+        let size_limit = actual_size.min(vm.config().single_memory_operation_size_limit);
 
         let polling_interval = vm.watchdog().poll_every();
 

--- a/src/opcode/memory.rs
+++ b/src/opcode/memory.rs
@@ -6,7 +6,6 @@ use crate::{
     constant::{
         CONTRACT_MAXIMUM_SIZE_BYTES,
         DUP_OPCODE_BASE_VALUE,
-        MEMORY_SINGLE_OPERATION_MAX_BYTES,
         PUSH_OPCODE_BASE_VALUE,
         PUSH_OPCODE_MAX_BYTES,
         SWAP_OPCODE_BASE_VALUE,
@@ -177,7 +176,7 @@ impl Opcode for CallDataCopy {
             // We bound the copied size to the contract size as anything bigger is going to
             // be impossible at runtime
             let actual_size: usize = value.into();
-            let size_limit = actual_size.min(MEMORY_SINGLE_OPERATION_MAX_BYTES);
+            let size_limit = actual_size.min(vm.config().single_memory_operation_size_limit);
 
             let polling_interval = vm.watchdog().poll_every();
 
@@ -669,7 +668,7 @@ impl Opcode for ReturnDataCopy {
             // We bound the copied size to the contract size as anything bigger is going to
             // be impossible at runtime
             let actual_size: usize = value.into();
-            let size_limit = actual_size.min(MEMORY_SINGLE_OPERATION_MAX_BYTES);
+            let size_limit = actual_size.min(vm.config().single_memory_operation_size_limit);
 
             let polling_interval = vm.watchdog().poll_every();
 

--- a/src/vm/thread.rs
+++ b/src/vm/thread.rs
@@ -101,9 +101,8 @@ impl From<VMThread> for VMState {
 #[cfg(test)]
 mod test {
     use crate::{
-        constant::DEFAULT_ITERATIONS_PER_OPCODE,
         disassembly::InstructionStream,
-        vm::{state::VMState, thread::VMThread},
+        vm::{state::VMState, thread::VMThread, Config},
     };
 
     #[test]
@@ -113,7 +112,7 @@ mod test {
         )?;
         let state = VMState::new_at_start(
             u32::try_from(instruction_stream.len()).unwrap(),
-            DEFAULT_ITERATIONS_PER_OPCODE,
+            Config::default(),
         );
         let execution_thread = instruction_stream.new_thread(0)?;
         let mut vm_thread = VMThread::new(state, execution_thread);


### PR DESCRIPTION
# Summary

After the recent major refactor to fix a correctness bug in the type-checker, the inference engine continued to hang onto the execution result which it no longer needed. This is now no longer the case, resulting in an approximate halving of maximum memory usage.

In addition, this also makes the maximum number of bytes that can be operated on in a single VM memory operation configurable externally, providing another point through which library clients can tune memory usage.

This mitigates #65, but does not totally fix the underlying inefficiencies of the current value representation.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
