### PR TITLE
Implement inference for bytes

### DIFF
--- a/src/inference/debug.rs
+++ b/src/inference/debug.rs
@@ -181,7 +181,7 @@ pub fn collect_vars_in_tree_of(
     while let Some(tv) = tyvar_queue.pop_front() {
         let inferences = state.inferences_for(tv);
         inferences.iter().for_each(|i| match i {
-            TE::Any | TE::Word { .. } | TE::Conflict { .. } => (),
+            TE::Any | TE::Word { .. } | TE::Conflict { .. } | TE::Bytes => (),
             TE::Equal { id } => {
                 if !seen.contains(id) {
                     tyvar_queue.push_back(*id);

--- a/src/inference/expression.rs
+++ b/src/inference/expression.rs
@@ -51,6 +51,10 @@ pub enum TypeExpression {
         usage: WordUse,
     },
 
+    /// A dynamic packed byte array, or a `string` given we have no way to
+    /// distinguish them at runtime.
+    Bytes,
+
     /// A static array containing items of type `element` and with `length`.
     FixedArray { element: TypeVariable, length: U256 },
 
@@ -206,7 +210,7 @@ impl TypeExpression {
     #[must_use]
     pub fn is_type_constructor(&self) -> bool {
         match self {
-            Self::Any | Self::Word { .. } | Self::Conflict { .. } => false,
+            Self::Any | Self::Word { .. } | Self::Conflict { .. } | TE::Bytes => false,
             Self::FixedArray { .. }
             | Self::Mapping { .. }
             | Self::DynamicArray { .. }
@@ -234,6 +238,7 @@ impl Display for TypeExpression {
                     write!(f, "Word<{usage}, ???>")
                 }
             }
+            Self::Bytes => write!(f, "bytes"),
             Self::FixedArray { element, length } => write!(f, "Array<{element}>[{length}]"),
             Self::Mapping { key, value } => write!(f, "Mapping<{key}, {value}>"),
             Self::DynamicArray { element } => write!(f, "Array<{element}>"),

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -361,6 +361,7 @@ impl InferenceEngine {
                     AbiType::Function.into()
                 }
             },
+            TE::Bytes => AbiType::DynBytes.into(),
             TE::FixedArray { element, length } => {
                 let tp = self
                     .abi_type_for_impl(element, seen_exprs, ParentType::Other)?

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -48,29 +48,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(3, 0, AbiType::Number { size: Some(8) }))
     );
 
-    // `string` but we infer `conflict`
-    assert_eq!(layout.slots()[4].index, 4);
-    assert_eq!(layout.slots()[4].offset, 0);
-    assert!(matches!(
-        &layout.slots()[4].typ,
-        AbiType::ConflictedType { .. }
-    ));
+    // `string` but we infer `bytes`
+    assert!(layout.slots().contains(&StorageSlot::new(4, 0, AbiType::DynBytes)));
 
-    // `string` but we infer `conflict`
-    assert_eq!(layout.slots()[5].index, 5);
-    assert_eq!(layout.slots()[5].offset, 0);
-    assert!(matches!(
-        &layout.slots()[5].typ,
-        AbiType::ConflictedType { .. }
-    ));
+    // `string` but we infer `bytes`
+    assert!(layout.slots().contains(&StorageSlot::new(5, 0, AbiType::DynBytes)));
 
-    // `string` but we infer `conflict`
-    assert_eq!(layout.slots()[6].index, 6);
-    assert_eq!(layout.slots()[6].offset, 0);
-    assert!(matches!(
-        &layout.slots()[6].typ,
-        AbiType::ConflictedType { .. }
-    ));
+    // `string` but we infer `bytes`
+    assert!(layout.slots().contains(&StorageSlot::new(6, 0, AbiType::DynBytes)));
 
     // `address` but we infer `bytes20`
     assert!(
@@ -103,13 +88,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `uint256` but we miss it entirely
     assert!(!layout.slots().iter().any(|slot| slot.index == 11));
 
-    // `string` but we infer `conflict`
-    assert_eq!(layout.slots()[12].index, 12);
-    assert_eq!(layout.slots()[12].offset, 0);
-    assert!(matches!(
-        &layout.slots()[12].typ,
-        AbiType::ConflictedType { .. }
-    ));
+    // `string` but we infer `bytes`
+    assert!(layout.slots().contains(&StorageSlot::new(12, 0, AbiType::DynBytes)));
 
     // `mapping(uint256 => struct)` but we infer `mapping(uint256 => uint256)`
     assert!(layout.slots().contains(&StorageSlot::new(


### PR DESCRIPTION
# Summary

While there is no way for the analyzer to distinguish bytes from string, we now can resolve a type as bytes instead of a conflict.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
