### PR TITLE
Output slot indices as uint256

### DIFF
--- a/asset/EIP1967Slot.sol
+++ b/asset/EIP1967Slot.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+contract EIP1967Slot {
+    // bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1))
+    bytes32 internal constant _IMPLEMENTATION_SLOT = 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    constructor() {
+        writeSlot(_IMPLEMENTATION_SLOT, 0x6bf5ed59dE0E19999d264746843FF931c0133090);
+    }
+
+    function implementation() public view returns (address) {
+        return readSlot(_IMPLEMENTATION_SLOT);
+    }
+
+    function writeSlot(bytes32 slot, address value) public {
+        assembly {
+            sstore(slot, value)
+        }
+    }
+
+    function readSlot(bytes32 slot) public view returns (address r) {
+        assembly {
+            r := sload(slot)
+        }
+    }
+}

--- a/src/inference/abi.rs
+++ b/src/inference/abi.rs
@@ -1,8 +1,9 @@
 //! This module contains the definition of the solidity ABI types that the
 //! analyzer is currently capable of dealing with.
 
-use ethnum::U256;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
+
+use crate::utility::U256Wrapper;
 
 /// Concretely known Solidity ABI types.
 ///
@@ -94,31 +95,6 @@ pub enum AbiType {
     ConflictedType { conflicts: Vec<String>, reasons: Vec<String> },
 }
 
-/// The `U256Wrapper` is responsible for serializing the U256 type to JSON
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-#[repr(transparent)]
-pub struct U256Wrapper(pub U256);
-
-impl Serialize for U256Wrapper {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut value = String::from("0x");
-        value.push_str(&hex::encode(self.0.to_be_bytes()));
-
-        serializer.serialize_str(&value)
-    }
-}
-
-impl<'de> Deserialize<'de> for U256Wrapper {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: String = Deserialize::deserialize(deserializer)?;
-        let u256 = U256::from_str_hex(&s).map_err(serde::de::Error::custom)?;
-        Ok(U256Wrapper(u256))
-    }
-}
-
 /// An element of a struct in the ABI.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -146,7 +122,7 @@ mod tests {
     use ethnum::U256;
     use serde_json::json;
 
-    use super::U256Wrapper;
+    use crate::utility::U256Wrapper;
 
     #[test]
     fn can_be_serialized() {

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::inference::abi::AbiType;
+use crate::{inference::abi::AbiType, utility::U256Wrapper};
 
 /// The most-concrete layout discovered for the input contract.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -14,7 +14,7 @@ pub struct StorageLayout {
 
 impl StorageLayout {
     /// Adds a slot specified by `index` and `typ` to the storage layout.
-    pub fn add(&mut self, index: usize, offset: usize, typ: AbiType) {
+    pub fn add(&mut self, index: impl Into<U256Wrapper>, offset: usize, typ: AbiType) {
         let slot = StorageSlot::new(index, offset, typ);
         self.slots.push(slot);
 
@@ -43,7 +43,7 @@ impl Default for StorageLayout {
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct StorageSlot {
     /// The concrete index of the storage slot in the contract.
-    pub index: usize,
+    pub index: U256Wrapper,
 
     /// The offset at which the type starts within the storage slot.
     ///
@@ -59,7 +59,8 @@ impl StorageSlot {
     /// Constructs a new storage slot container for the data at `index` with
     /// type `typ`.
     #[must_use]
-    pub fn new(index: usize, offset: usize, typ: AbiType) -> Self {
+    pub fn new(index: impl Into<U256Wrapper>, offset: usize, typ: AbiType) -> Self {
+        let index = index.into();
         Self { index, offset, typ }
     }
 }

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,6 +1,12 @@
 //! Utility functions useful throughout the codebase.
 
+use std::cmp::Ordering;
+
+use ethnum::U256;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
+
+use crate::vm::value::known::KnownWord;
 
 /// Formats a UUID as the first 16 bytes in hex, rather than the full thing.
 /// This allows for more-compact printing.
@@ -8,4 +14,84 @@ use uuid::Uuid;
 pub fn clip_uuid(uuid: &Uuid) -> String {
     let string = format!("{uuid}");
     string[0..8].to_string()
+}
+
+/// A type alias to make [`U256Wrapper`] easier to type internally.
+pub type U256W = U256Wrapper;
+
+/// The `U256Wrapper` is responsible for allowing the serialisation of the
+/// [`U256`] type to JSON.
+///
+/// It provides reasonable conversions from a number of common types used within
+/// the library.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct U256Wrapper(pub U256);
+
+impl PartialOrd for U256Wrapper {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl Ord for U256Wrapper {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl From<U256> for U256Wrapper {
+    fn from(value: U256) -> Self {
+        Self(value)
+    }
+}
+
+impl From<U256Wrapper> for U256 {
+    fn from(U256Wrapper(value): U256Wrapper) -> Self {
+        value
+    }
+}
+
+impl From<KnownWord> for U256Wrapper {
+    fn from(value: KnownWord) -> Self {
+        Self(value.value_le())
+    }
+}
+
+impl From<&KnownWord> for U256Wrapper {
+    fn from(value: &KnownWord) -> Self {
+        Self(value.value_le())
+    }
+}
+
+impl From<U256Wrapper> for KnownWord {
+    fn from(value: U256Wrapper) -> Self {
+        KnownWord::from_le(value.0)
+    }
+}
+
+impl From<usize> for U256Wrapper {
+    fn from(value: usize) -> Self {
+        Self(U256::from(value as u128))
+    }
+}
+
+impl Serialize for U256Wrapper {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut value = String::from("0x");
+        value.push_str(&hex::encode(self.0.to_be_bytes()));
+
+        serializer.serialize_str(&value)
+    }
+}
+
+impl<'de> Deserialize<'de> for U256Wrapper {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = Deserialize::deserialize(deserializer)?;
+        let u256 = U256::from_str_hex(&s).map_err(serde::de::Error::custom)?;
+        Ok(U256Wrapper(u256))
+    }
 }

--- a/tests/eip1967_slot.rs
+++ b/tests/eip1967_slot.rs
@@ -1,0 +1,35 @@
+//! This module provides a simple integration test that ensures that we can
+//! discover very large slot numbers such as those used in EIP-1967 based
+//! contracts.
+#![cfg(test)]
+
+use ethnum::U256;
+use storage_layout_analyzer::{
+    inference::abi::AbiType,
+    layout::StorageSlot,
+    watchdog::LazyWatchdog,
+};
+
+mod common;
+
+#[test]
+fn correctly_returns_large_slot() -> anyhow::Result<()> {
+    // Create the analyzer
+    let bytecode = "0x608060405234801561001057600080fd5b50600436106100415760003560e01c80635c60da1b14610046578063b06cb8991461006a578063e8e834a91461007e575b600080fd5b61004e610090565b6040516001600160a01b03909116815260200160405180910390f35b61007c6100783660046100bf565b9055565b005b61004e61008c3660046100fb565b5490565b60006100ba7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5490565b905090565b600080604083850312156100d257600080fd5b8235915060208301356001600160a01b03811681146100f057600080fd5b809150509250929050565b60006020828403121561010d57600080fd5b503591905056fea2646970667358221220d65a69a7da4e10e131d4d9d13cf5abd64991e0201c1d86b2c4cb0c4aef279e1764736f6c63430008090033";
+    let analyzer = common::new_analyzer_from_bytecode(bytecode, LazyWatchdog.in_rc())?;
+
+    // Get the final storage layout for the input contract
+    let layout = analyzer.analyze()?;
+
+    // Inspect it to check that things are correct
+    assert_eq!(layout.slots().len(), 1);
+
+    // Check that we see a slot at the huge value
+    assert!(layout.slots().contains(&StorageSlot::new(
+        U256::from_str_hex("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?,
+        0,
+        AbiType::Bytes { length: Some(20) }
+    )));
+
+    Ok(())
+}

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -5,6 +5,7 @@
 use storage_layout_analyzer::{
     inference::abi::{AbiType, StructElement},
     layout::StorageSlot,
+    utility::U256W,
     watchdog::LazyWatchdog,
 };
 
@@ -86,7 +87,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     );
 
     // `uint256` but we miss it entirely
-    assert!(!layout.slots().iter().any(|slot| slot.index == 11));
+    assert!(!layout.slots().iter().any(|slot| slot.index == U256W::from(11)));
 
     // `string` but we infer `bytes`
     assert!(layout.slots().contains(&StorageSlot::new(12, 0, AbiType::DynBytes)));


### PR DESCRIPTION
# Summary

Previously these were being truncated to 64 bits due to a bad assumption, which was cutting off implementation slot indices in some cases.

Fixes #70.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
