### PR TITLE
Add support for large structs in mappings

### DIFF
--- a/src/inference/lift/mapping_access.rs
+++ b/src/inference/lift/mapping_access.rs
@@ -45,9 +45,10 @@ impl Lift for MappingAccess {
                 return None;
             };
 
-            Some(RSVD::MappingAccess {
-                key:  key.clone().transform_data(insert_mapping_accesses),
-                slot: slot.clone().transform_data(insert_mapping_accesses),
+            Some(RSVD::MappingIndex {
+                key:        key.clone().transform_data(insert_mapping_accesses),
+                slot:       slot.clone().transform_data(insert_mapping_accesses),
+                projection: None,
             })
         }
 
@@ -83,7 +84,12 @@ mod test {
         let result = MappingAccess.run(hash, &state)?;
 
         match result.data() {
-            RSVD::MappingAccess { key, slot } => {
+            RSVD::MappingIndex {
+                key,
+                slot,
+                projection,
+            } => {
+                assert!(projection.is_none());
                 assert_eq!(key, &input_key);
                 assert_eq!(slot, &input_slot);
             }
@@ -125,11 +131,21 @@ mod test {
         let result = MappingAccess.run(outer_hash, &state)?;
 
         match result.data() {
-            RSVD::MappingAccess { key, slot } => {
+            RSVD::MappingIndex {
+                key,
+                slot,
+                projection,
+            } => {
+                assert!(projection.is_none());
                 assert_eq!(key, &input_key);
 
                 match slot.data() {
-                    RSVD::MappingAccess { key, slot } => {
+                    RSVD::MappingIndex {
+                        key,
+                        slot,
+                        projection,
+                    } => {
+                        assert!(projection.is_none());
                         assert_eq!(key, &input_key);
                         assert_eq!(slot, &input_slot);
                     }

--- a/src/inference/lift/mapping_offset.rs
+++ b/src/inference/lift/mapping_offset.rs
@@ -1,0 +1,183 @@
+//! This module provides a lifting pass that recognises offset accesses to
+//! mapping storage slots to account for larger structs as mapping values.
+
+use crate::{
+    inference::{lift::Lift, state::InferenceState},
+    vm::value::{RuntimeBoxedVal, RSVD},
+};
+
+/// This pass detects and folds expressions that access values in mappings that
+/// are larger than one word.
+///
+/// ```code
+/// slot<offset + mapping_ix<slot_ix>[key][0]>
+///
+/// becomes
+///
+/// slot<mapping_ix<slot_ix>[key][offset]>
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct MappingOffset;
+
+impl MappingOffset {
+    /// Constructs a new instance of the mapping offset lifting pass.
+    #[must_use]
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+}
+
+impl Lift for MappingOffset {
+    fn run(
+        &mut self,
+        value: RuntimeBoxedVal,
+        _state: &InferenceState,
+    ) -> crate::error::unification::Result<RuntimeBoxedVal> {
+        fn insert_mapping_offset(data: &RSVD) -> Option<RSVD> {
+            let RSVD::Add { left, right } = data else { return None };
+
+            let (key, slot, offset) = match (left.data(), right.data()) {
+                (RSVD::MappingIndex { key, slot, .. }, RSVD::KnownData { value })
+                | (RSVD::KnownData { value }, RSVD::MappingIndex { key, slot, .. }) => {
+                    (key, slot, value.into())
+                }
+                _ => return None,
+            };
+
+            Some(RSVD::MappingIndex {
+                key:        key.clone().transform_data(insert_mapping_offset),
+                slot:       slot.clone().transform_data(insert_mapping_offset),
+                projection: Some(offset),
+            })
+        }
+
+        Ok(value.transform_data(insert_mapping_offset))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            lift::{mapping_offset::MappingOffset, Lift},
+            state::InferenceState,
+        },
+        vm::value::{known::KnownWord, Provenance, RSV, RSVD},
+    };
+
+    #[test]
+    fn discovers_mapping_offsets_at_top_level() -> anyhow::Result<()> {
+        // Create some input values
+        let input_key = RSV::new_value(0, Provenance::Synthetic);
+        let input_slot = RSV::new_known_value(1, KnownWord::from(10), Provenance::Synthetic, None);
+        let mapping = RSV::new_synthetic(
+            2,
+            RSVD::MappingIndex {
+                slot:       input_slot.clone(),
+                key:        input_key.clone(),
+                projection: None,
+            },
+        );
+        let constant = RSV::new_known_value(3, KnownWord::from(256), Provenance::Synthetic, None);
+        let add = RSV::new_synthetic(
+            4,
+            RSVD::Add {
+                left:  mapping.clone(),
+                right: constant.clone(),
+            },
+        );
+
+        // Run the lifting pass
+        let state = InferenceState::empty();
+        let result = MappingOffset.run(add, &state)?;
+
+        // Check that the values make sense
+        match result.data() {
+            RSVD::MappingIndex {
+                key,
+                slot,
+                projection,
+            } => {
+                assert_eq!(key, &input_key);
+                assert_eq!(slot, &input_slot);
+                assert_eq!(projection, &Some(256));
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn discovers_mapping_offsets_when_nested() -> anyhow::Result<()> {
+        // Create some input values
+        let input_key = RSV::new_value(0, Provenance::Synthetic);
+        let input_slot = RSV::new_known_value(1, KnownWord::from(10), Provenance::Synthetic, None);
+        let inner_mapping = RSV::new_synthetic(
+            2,
+            RSVD::MappingIndex {
+                slot:       input_slot.clone(),
+                key:        input_key.clone(),
+                projection: None,
+            },
+        );
+        let inner_constant =
+            RSV::new_known_value(3, KnownWord::from(256), Provenance::Synthetic, None);
+        let inner_add = RSV::new_synthetic(
+            4,
+            RSVD::Add {
+                left:  inner_mapping.clone(),
+                right: inner_constant.clone(),
+            },
+        );
+        let outer_mapping = RSV::new_synthetic(
+            5,
+            RSVD::MappingIndex {
+                slot:       inner_add.clone(),
+                key:        input_key.clone(),
+                projection: None,
+            },
+        );
+        let outer_constant =
+            RSV::new_known_value(6, KnownWord::from(512), Provenance::Synthetic, None);
+        let outer_add = RSV::new_synthetic(
+            7,
+            RSVD::Add {
+                left:  outer_constant.clone(),
+                right: outer_mapping.clone(),
+            },
+        );
+
+        // Run the lifting pass
+        let state = InferenceState::empty();
+        let result = MappingOffset.run(outer_add, &state)?;
+
+        // Check that the results make sense
+        match result.data() {
+            RSVD::MappingIndex {
+                key,
+                slot,
+                projection,
+            } => {
+                assert_eq!(key, &input_key);
+                assert_eq!(projection, &Some(512));
+
+                match slot.data() {
+                    RSVD::MappingIndex {
+                        key,
+                        slot,
+                        projection,
+                    } => {
+                        assert_eq!(key, &input_key);
+                        assert_eq!(slot, &input_slot);
+                        assert_eq!(projection, &Some(256));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/inference/lift/mod.rs
+++ b/src/inference/lift/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod dynamic_array_access;
 pub mod mapping_access;
+pub mod mapping_offset;
 pub mod mul_shifted;
 pub mod packed_encoding;
 pub mod recognise_hashed_slots;
@@ -23,6 +24,7 @@ use crate::{
         lift::{
             dynamic_array_access::DynamicArrayAccess,
             mapping_access::MappingAccess,
+            mapping_offset::MappingOffset,
             mul_shifted::MulShiftedValue,
             packed_encoding::PackedEncoding,
             recognise_hashed_slots::StorageSlotHashes,
@@ -134,6 +136,7 @@ impl Default for LiftingPasses {
                 PackedEncoding::new(),
                 DynamicArrayAccess::new(),
                 StorageSlots::new(),
+                MappingOffset::new(),
             ],
         }
     }

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -73,6 +73,11 @@ impl InferenceEngine {
     /// Returns [`Err`] if the engine's execution fails for any reason.
     pub fn run(&mut self, execution_result: &ExecutionResult) -> Result<StorageLayout> {
         let transformed_values = self.lift(execution_result)?;
+
+        // for value in &transformed_values {
+        //     println!("{value}");
+        // }
+
         self.assign_vars(transformed_values)?;
         self.infer()?;
         self.unify()
@@ -749,9 +754,10 @@ pub mod test {
         );
         let c_1_mapping = RSV::new(
             0,
-            RSVD::MappingAccess {
-                key:  v_1.clone(),
-                slot: c_1_slot.clone(),
+            RSVD::MappingIndex {
+                key:        v_1.clone(),
+                slot:       c_1_slot.clone(),
+                projection: None,
             },
             Provenance::Synthetic,
             None,
@@ -823,9 +829,10 @@ pub mod test {
         );
         let mapping = RSV::new(
             4,
-            RSVD::MappingAccess {
-                slot: storage_slot.clone(),
-                key:  add.clone(),
+            RSVD::MappingIndex {
+                slot:       storage_slot.clone(),
+                key:        add.clone(),
+                projection: None,
             },
             Provenance::Synthetic,
             None,

--- a/src/utility.rs
+++ b/src/utility.rs
@@ -1,6 +1,9 @@
 //! Utility functions useful throughout the codebase.
 
-use std::cmp::Ordering;
+use std::{
+    cmp::Ordering,
+    fmt::{Debug, Formatter},
+};
 
 use ethnum::U256;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -24,9 +27,17 @@ pub type U256W = U256Wrapper;
 ///
 /// It provides reasonable conversions from a number of common types used within
 /// the library.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct U256Wrapper(pub U256);
+
+impl Debug for U256Wrapper {
+    /// The wrapper has absolutely no semantic meaning, so we print the
+    /// underlying value for the debug representation.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl PartialOrd for U256Wrapper {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {

--- a/tests/balancers_vault.rs
+++ b/tests/balancers_vault.rs
@@ -32,8 +32,9 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(0, 0, AbiType::Bytes { length: None }))
     );
 
-    // `mapping(bytes32 => struct)` but we infer `mapping(struct(any, uint16,
-    // bytes20) => uintUnknown)`
+    // `mapping(bytes32 => struct)` but we infer `mapping(struct(bytes10, uint16,
+    // bytes20) => struct(uintUnknown, mapping(numberUnknown => struct(bytes20,
+    // bytes14, bytes14)), mapping(bytes20 => numberUnknown)))`
     assert!(layout.slots().contains(&StorageSlot::new(
         1,
         0,
@@ -45,7 +46,31 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                     StructElement::new(96, AbiType::Bytes { length: Some(20) })
                 ],
             }),
-            value_type: Box::new(AbiType::UInt { size: None }),
+            value_type: Box::new(AbiType::Struct {
+                elements: vec![
+                    StructElement::new(0, AbiType::UInt { size: None }),
+                    StructElement::new(
+                        256,
+                        AbiType::Mapping {
+                            key_type:   Box::new(AbiType::Number { size: None }),
+                            value_type: Box::new(AbiType::Struct {
+                                elements: vec![
+                                    StructElement::new(0, AbiType::Bytes { length: Some(20) }),
+                                    StructElement::new(256, AbiType::Bytes { length: Some(14) }),
+                                    StructElement::new(368, AbiType::Bytes { length: Some(14) }),
+                                ],
+                            }),
+                        }
+                    ),
+                    StructElement::new(
+                        512,
+                        AbiType::Mapping {
+                            key_type:   Box::new(AbiType::Bytes { length: Some(20) }),
+                            value_type: Box::new(AbiType::Number { size: None }),
+                        }
+                    )
+                ],
+            }),
         }
     )));
 
@@ -88,8 +113,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(bytes32 => bool)` but we infer `mapping(struct(any, uint16, bytes20)
-    // => struct(number8, bytes31)`
+    // `mapping(bytes32 => bool)` but we infer `mapping(struct(bytes10, uint16,
+    // bytes20) => struct(number8, bytes31)`
     assert!(layout.slots().contains(&StorageSlot::new(
         5,
         0,
@@ -118,7 +143,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     );
 
     // `mapping(bytes32 => mapping(address => bytes32)` but we infer
-    // `mapping(struct(any, uint16, bytes20) => mapping(bytes20 =>
+    // `mapping(struct(bytes10, uint16, bytes20) => mapping(bytes20 =>
     // struct(bytes14, bytes14)))`
     assert!(layout.slots().contains(&StorageSlot::new(
         7,
@@ -143,8 +168,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(bytes32 => struct)` but we infer `mapping(struct(uint16, any) =>
-    // uintUnknown)`
+    // `mapping(bytes32 => struct)` but we infer `mapping(struct(bytes10, uint16,
+    // bytes20) => struct(uintUnknown, mapping(bytes20 => numberUnknown)))`
     assert!(layout.slots().contains(&StorageSlot::new(
         8,
         0,
@@ -156,12 +181,24 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                     StructElement::new(96, AbiType::Bytes { length: Some(20) })
                 ],
             }),
-            value_type: Box::new(AbiType::UInt { size: None }),
+            value_type: Box::new(AbiType::Struct {
+                elements: vec![
+                    StructElement::new(0, AbiType::UInt { size: None }),
+                    StructElement::new(
+                        256,
+                        AbiType::Mapping {
+                            key_type:   Box::new(AbiType::Bytes { length: Some(20) }),
+                            value_type: Box::new(AbiType::Number { size: None }),
+                        }
+                    )
+                ],
+            }),
         }
     )));
 
-    // `mapping(bytes32 => struct)` but we infer `mapping(struct(uint16, any) =>
-    // number160)`
+    // `mapping(bytes32 => struct)` but we infer `mapping(struct(bytes10, uint16,
+    // bytes20) => struct(number160, number160, mapping(bytes32 => struct(uint112,
+    // uint112, number112, number112))))`
     assert!(layout.slots().contains(&StorageSlot::new(
         9,
         0,
@@ -173,7 +210,26 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                     StructElement::new(96, AbiType::Bytes { length: Some(20) })
                 ],
             }),
-            value_type: Box::new(AbiType::Number { size: Some(160) }),
+            value_type: Box::new(AbiType::Struct {
+                elements: vec![
+                    StructElement::new(0, AbiType::Number { size: Some(160) }),
+                    StructElement::new(256, AbiType::Number { size: Some(160) }),
+                    StructElement::new(
+                        512,
+                        AbiType::Mapping {
+                            key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
+                            value_type: Box::new(AbiType::Struct {
+                                elements: vec![
+                                    StructElement::new(0, AbiType::UInt { size: Some(112) }),
+                                    StructElement::new(112, AbiType::UInt { size: Some(112) }),
+                                    StructElement::new(256, AbiType::Number { size: Some(112) }),
+                                    StructElement::new(368, AbiType::Number { size: Some(112) }),
+                                ],
+                            }),
+                        }
+                    ),
+                ],
+            }),
         }
     )));
 

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -58,18 +58,15 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `string` but we infer `bytes`
     assert!(layout.slots().contains(&StorageSlot::new(6, 0, AbiType::DynBytes)));
 
-    // `address` but we infer `bytes20`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(7, 0, AbiType::Bytes { length: Some(20) }))
-    );
+    // `address`
+    assert!(layout.slots().contains(&StorageSlot::new(7, 0, AbiType::Address)));
 
-    // `packed(address, bool)` but we infer `bytes20`
+    // `packed(address, bool)` but we infer `packed(address, number8)`
+    assert!(layout.slots().contains(&StorageSlot::new(8, 0, AbiType::Address)));
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(8, 0, AbiType::Bytes { length: Some(20) }))
+            .contains(&StorageSlot::new(8, 160, AbiType::Number { size: Some(8) }))
     );
 
     // `uint256`
@@ -92,13 +89,35 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `string` but we infer `bytes`
     assert!(layout.slots().contains(&StorageSlot::new(12, 0, AbiType::DynBytes)));
 
-    // `mapping(uint256 => struct)` but we infer `mapping(uint256 => uint256)`
+    // `mapping(uint256 => struct)` but we infer `mapping(uint256 => struct)` but
+    // the struct is not quite the same
     assert!(layout.slots().contains(&StorageSlot::new(
         13,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Number { size: Some(256) }),
-            value_type: Box::new(AbiType::Number { size: Some(256) }),
+            value_type: Box::new(AbiType::Struct {
+                elements: vec![
+                    StructElement::new(0, AbiType::Number { size: Some(256) }),
+                    StructElement::new(256, AbiType::Address),
+                    StructElement::new(416, AbiType::Number { size: Some(8) }),
+                    StructElement::new(512, AbiType::Bytes { length: Some(32) }),
+                    StructElement::new(768, AbiType::Bytes { length: Some(32) }),
+                    StructElement::new(1024, AbiType::Bytes { length: Some(32) }),
+                    StructElement::new(1280, AbiType::Number { size: Some(8) }),
+                    StructElement::new(1288, AbiType::Bytes { length: Some(31) }),
+                    StructElement::new(1536, AbiType::UInt { size: Some(256) }),
+                    StructElement::new(1792, AbiType::UInt { size: None }),
+                    StructElement::new(2048, AbiType::Number { size: Some(8) }),
+                    StructElement::new(2056, AbiType::Bytes { length: Some(31) }),
+                    StructElement::new(2304, AbiType::UInt { size: Some(256) }),
+                    StructElement::new(2560, AbiType::UInt { size: Some(256) }),
+                    StructElement::new(2816, AbiType::Number { size: Some(256) }),
+                    StructElement::new(3072, AbiType::Bytes { length: Some(20) }),
+                    StructElement::new(3232, AbiType::Bytes { length: Some(1) }),
+                    StructElement::new(3240, AbiType::Any),
+                ],
+            }),
         }
     )));
 

--- a/tests/uniswap_permit2.rs
+++ b/tests/uniswap_permit2.rs
@@ -24,9 +24,6 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // We should see 2 slots
     assert_eq!(layout.slots().len(), 2);
 
-    // Currently all slots are suffering from being conflicts, so we can only assert
-    // the portions of the inferred type that are correct
-
     // `mapping(address => mapping(uint256 => uint256))` but we infer
     // `mapping(address => mapping(bytes32 => bytesUnknown))`
     assert!(layout.slots().contains(&StorageSlot::new(


### PR DESCRIPTION
# Summary

The analyzer is now capable of discovering structs that occupy more than one word of storage when they are used as mapping values. The tests have been updated to reflect this, and we discover a significant number of manually-packed encodings in the benchmark contracts accurately.

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
