### PR TITLE
Add support for dynamic arrays inside structs

### DIFF
--- a/docs/Extending the Analyzer.md
+++ b/docs/Extending the Analyzer.md
@@ -164,7 +164,7 @@ higher_level(expression, parts)
 ```
 
 Let's work through an example lifting pass for finding accesses to mappings in storage as is
-implemented [here](../src/inference/lift/mapping_access.rs).
+implemented [here](../src/inference/lift/mapping_index.rs).
 
 First we start by writing out the low-level pattern that we are trying to represent at a
 higher-level, using variable names to describe the arguments where their structure is irrelevant to
@@ -185,4 +185,4 @@ mapping_ix<slot_ix>[key]
 ```
 
 Now all that remains is to implement and test it, as can be seen in the
-codebase [here](../src/inference/lift/mapping_access.rs).
+codebase [here](../src/inference/lift/mapping_index.rs).

--- a/src/inference/lift/mapping_index.rs
+++ b/src/inference/lift/mapping_index.rs
@@ -1,4 +1,4 @@
-//! This module provides a lifting pass that recognises accesses to
+//! This module provides a lifting pass that recognises  to
 //! individual storage slots as part of a mapping.
 
 use crate::{
@@ -6,7 +6,8 @@ use crate::{
     vm::value::{RuntimeBoxedVal, RSVD},
 };
 
-/// This pass detects and folds expressions that access mappings in storage.
+/// This pass detects and folds expressions that represent indices into mappings
+/// in storage.
 ///
 /// These have a form as follows:
 ///
@@ -22,9 +23,9 @@ use crate::{
 /// [`RSVD::SLoad`] and [`RSVD::UnwrittenStorageValue`] to ensure that we do not
 /// inadvertently capture non-mapping access patterns as mappings.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct MappingAccess;
+pub struct MappingIndex;
 
-impl MappingAccess {
+impl MappingIndex {
     /// Constructs a new instance of the mapping access lifting pass.
     #[must_use]
     pub fn new() -> Box<Self> {
@@ -32,7 +33,7 @@ impl MappingAccess {
     }
 }
 
-impl Lift for MappingAccess {
+impl Lift for MappingIndex {
     fn run(
         &mut self,
         value: RuntimeBoxedVal,
@@ -81,7 +82,7 @@ impl Lift for MappingAccess {
 mod test {
     use crate::{
         inference::{
-            lift::{mapping_access::MappingAccess, Lift},
+            lift::{mapping_index::MappingIndex, Lift},
             state::InferenceState,
         },
         vm::value::{known::KnownWord, Provenance, RSV, RSVD},
@@ -110,7 +111,7 @@ mod test {
         );
 
         let state = InferenceState::empty();
-        let result = MappingAccess.run(s_load, &state)?;
+        let result = MappingIndex.run(s_load, &state)?;
 
         match result.data() {
             RSVD::SLoad { key, value } => {
@@ -172,7 +173,7 @@ mod test {
         );
 
         let state = InferenceState::empty();
-        let result = MappingAccess.run(s_store, &state)?;
+        let result = MappingIndex.run(s_store, &state)?;
 
         match result.data() {
             RSVD::StorageWrite { key, value } => {

--- a/src/inference/lift/mod.rs
+++ b/src/inference/lift/mod.rs
@@ -3,7 +3,7 @@
 //! lower-level patterns.
 
 pub mod dynamic_array_access;
-pub mod mapping_access;
+pub mod mapping_index;
 pub mod mapping_offset;
 pub mod mul_shifted;
 pub mod packed_encoding;
@@ -22,8 +22,8 @@ use crate::{
     error::unification::Result,
     inference::{
         lift::{
-            dynamic_array_access::DynamicArrayAccess,
-            mapping_access::MappingAccess,
+            dynamic_array_access::DynamicArrayIndex,
+            mapping_index::MappingIndex,
             mapping_offset::MappingOffset,
             mul_shifted::MulShiftedValue,
             packed_encoding::PackedEncoding,
@@ -130,11 +130,11 @@ impl Default for LiftingPasses {
         Self {
             passes: vec![
                 StorageSlotHashes::new(),
-                MappingAccess::new(),
+                MappingIndex::new(),
                 SubWordValue::new(),
                 MulShiftedValue::new(),
                 PackedEncoding::new(),
-                DynamicArrayAccess::new(),
+                DynamicArrayIndex::new(),
                 StorageSlots::new(),
                 MappingOffset::new(),
             ],

--- a/src/inference/lift/storage_slots.rs
+++ b/src/inference/lift/storage_slots.rs
@@ -10,7 +10,7 @@ use crate::{
 /// so that these constants can be distinguished from other constants of the
 /// same value.
 ///
-/// This pass relies on the results of the [`super::mapping_access`] pass, and
+/// This pass relies on the results of the [`super::mapping_index`] pass, and
 /// hence must be ordered after it in the lifting pass ordering.
 ///
 /// # Note
@@ -67,7 +67,7 @@ impl Lift for StorageSlots {
                         value: value.clone().transform_data(insert_storage_accesses),
                     })
                 }
-                RSVD::DynamicArrayAccess { slot, index } => {
+                RSVD::DynamicArrayIndex { slot, index } => {
                     let data = match &slot.data() {
                         RSVD::StorageSlot { .. } => slot.data().clone(),
                         _ => RSVD::StorageSlot {
@@ -75,7 +75,7 @@ impl Lift for StorageSlots {
                         },
                     };
                     let slot = RSV::new(slot.instruction_pointer(), data, slot.provenance(), None);
-                    Some(RSVD::DynamicArrayAccess {
+                    Some(RSVD::DynamicArrayIndex {
                         index: index.clone().transform_data(insert_storage_accesses),
                         slot,
                     })
@@ -250,7 +250,7 @@ mod test {
         let input_index = RSV::new_value(1, Provenance::Synthetic);
         let dyn_array = RSV::new(
             2,
-            RSVD::DynamicArrayAccess {
+            RSVD::DynamicArrayIndex {
                 slot:  input_slot.clone(),
                 index: input_index.clone(),
             },
@@ -262,7 +262,7 @@ mod test {
         let result = StorageSlots.run(dyn_array, &state)?;
 
         match result.data() {
-            RSVD::DynamicArrayAccess { slot, index } => {
+            RSVD::DynamicArrayIndex { slot, index } => {
                 assert_eq!(index, &input_index);
 
                 match slot.data() {
@@ -367,7 +367,7 @@ mod test {
         let input_index = RSV::new_value(1, Provenance::Synthetic);
         let dyn_array = RSV::new(
             2,
-            RSVD::DynamicArrayAccess {
+            RSVD::DynamicArrayIndex {
                 slot:  input_slot.clone(),
                 index: input_index.clone(),
             },
@@ -379,7 +379,7 @@ mod test {
         let result = StorageSlots.run(dyn_array, &state)?;
 
         match result.data() {
-            RSVD::DynamicArrayAccess { slot, index } => {
+            RSVD::DynamicArrayIndex { slot, index } => {
                 assert_eq!(index, &input_index);
                 assert_eq!(slot, &input_slot);
             }

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -73,11 +73,6 @@ impl InferenceEngine {
     /// Returns [`Err`] if the engine's execution fails for any reason.
     pub fn run(&mut self, execution_result: &ExecutionResult) -> Result<StorageLayout> {
         let transformed_values = self.lift(execution_result)?;
-
-        // for value in &transformed_values {
-        //     println!("{value}");
-        // }
-
         self.assign_vars(transformed_values)?;
         self.infer()?;
         self.unify()

--- a/src/inference/rule/dynamic_array_write.rs
+++ b/src/inference/rule/dynamic_array_write.rs
@@ -31,7 +31,7 @@ impl InferenceRule for DynamicArrayWriteRule {
         let TCSVD::StorageSlot { key: c } = b.data() else {
             return Ok(());
         };
-        let TCSVD::DynamicArrayAccess { slot: d, index: f } = c.data() else {
+        let TCSVD::DynamicArrayIndex { slot: d, index: f } = c.data() else {
             return Ok(());
         };
         let TCSVD::StorageSlot { .. } = d.data() else {

--- a/src/inference/state.rs
+++ b/src/inference/state.rs
@@ -349,7 +349,7 @@ impl InferenceState {
                 key: self.register_internal(key),
                 projection,
             },
-            RSVD::DynamicArrayAccess { slot, index } => TCSVD::DynamicArrayAccess {
+            RSVD::DynamicArrayIndex { slot, index } => TCSVD::DynamicArrayIndex {
                 slot:  self.register_internal(slot),
                 index: self.register_internal(index),
             },

--- a/src/vm/value/mod.rs
+++ b/src/vm/value/mod.rs
@@ -640,7 +640,7 @@ pub enum SymbolicValueData<AuxData> {
 
     /// The value is a dynamic array access for the array with its length stored
     /// at `slot` and the `index` specifying the element in the array.
-    DynamicArrayAccess { slot: BoxedVal<AuxData>, index: BoxedVal<AuxData> },
+    DynamicArrayIndex { slot: BoxedVal<AuxData>, index: BoxedVal<AuxData> },
 
     /// An operation that masks `value` to construct a sub-word value.
     ///
@@ -793,7 +793,7 @@ where
             SVD::StorageWrite { key, value } => key.size() + value.size(),
             SVD::Concat { values } => values.iter().map(|v| v.size()).sum(),
             SVD::MappingIndex { slot, key, .. } => slot.size() + key.size(),
-            SVD::DynamicArrayAccess { slot, index } => slot.size() + index.size(),
+            SVD::DynamicArrayIndex { slot, index } => slot.size() + index.size(),
             SVD::SubWord { value, .. } => value.size(),
             SVD::Shifted { value, .. } => value.size(),
             SVD::Packed { elements } => elements.iter().map(|s| s.value.size()).sum(),
@@ -1033,7 +1033,7 @@ where
                     key: key.transform_data(transform),
                     projection,
                 },
-                Self::DynamicArrayAccess { slot, index } => Self::DynamicArrayAccess {
+                Self::DynamicArrayIndex { slot, index } => Self::DynamicArrayIndex {
                     slot:  slot.transform_data(transform),
                     index: index.transform_data(transform),
                 },
@@ -1342,7 +1342,7 @@ where
             Self::StorageWrite { key, value } => vec![key, value],
             Self::Concat { values } => values.iter().collect(),
             Self::MappingIndex { slot, key, .. } => vec![slot, key],
-            Self::DynamicArrayAccess { slot, index } => vec![slot, index],
+            Self::DynamicArrayIndex { slot, index } => vec![slot, index],
             Self::SubWord { value, .. } => vec![value],
             Self::Shifted { value, .. } => vec![value],
             Self::Packed { elements } => elements.iter().map(|e| &e.value).collect(),
@@ -1461,7 +1461,7 @@ where
             } => {
                 write!(f, "mapping_ix({slot})[{}][{key}]", projection.unwrap_or(0))
             }
-            Self::DynamicArrayAccess { slot, index } => write!(f, "dynamic_array({slot})[{index}]"),
+            Self::DynamicArrayIndex { slot, index } => write!(f, "dyn_arr_ix({slot})[{index}]"),
             Self::SubWord {
                 value,
                 offset,

--- a/tests/balancers_vault.rs
+++ b/tests/balancers_vault.rs
@@ -168,8 +168,9 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(bytes32 => struct)` but we infer `mapping(struct(bytes10, uint16,
-    // bytes20) => struct(uintUnknown, mapping(bytes20 => numberUnknown)))`
+    // `mapping(bytes32 => struct(address[], mapping(address => uint256)))` but we
+    // infer `mapping(struct(bytes10, uint16, bytes20) => struct(bytes20[],
+    // mapping(bytes20 => numberUnknown)))`
     assert!(layout.slots().contains(&StorageSlot::new(
         8,
         0,
@@ -183,7 +184,12 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             }),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
-                    StructElement::new(0, AbiType::UInt { size: None }),
+                    StructElement::new(
+                        0,
+                        AbiType::DynArray {
+                            tp: Box::new(AbiType::Bytes { length: Some(20) }),
+                        }
+                    ),
                     StructElement::new(
                         256,
                         AbiType::Mapping {

--- a/tests/crypto_kitties.rs
+++ b/tests/crypto_kitties.rs
@@ -63,12 +63,12 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(uint256 => address)` but we infer `mapping(uint32 => address)`
+    // `mapping(uint256 => address)` but we infer `mapping(number32 => address)`
     assert!(layout.slots().contains(&StorageSlot::new(
         7,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(32) }),
+            key_type:   Box::new(AbiType::Number { size: Some(32) }),
             value_type: Box::new(AbiType::Address),
         }
     )));
@@ -83,22 +83,22 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(uint256 => address)` but we infer `mapping(uint32 => address)`
+    // `mapping(uint256 => address)` but we infer `mapping(number32 => address)`
     assert!(layout.slots().contains(&StorageSlot::new(
         9,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(32) }),
+            key_type:   Box::new(AbiType::Number { size: Some(32) }),
             value_type: Box::new(AbiType::Address),
         }
     )));
 
-    // `mapping(uint256 => address)` but we infer `mapping(uint32 => bytes20)`
+    // `mapping(uint256 => address)` but we infer `mapping(number32 => bytes20)`
     assert!(layout.slots().contains(&StorageSlot::new(
         10,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(32) }),
+            key_type:   Box::new(AbiType::Number { size: Some(32) }),
             value_type: Box::new(AbiType::Bytes { length: Some(20) }),
         }
     )));

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -32,11 +32,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(0, 0, AbiType::Number { size: Some(160) }))
     );
 
-    // `uint256` but we infer `number256`
+    // `uint256`
     assert!(
         layout
             .slots()
-            .contains(&StorageSlot::new(1, 0, AbiType::Number { size: Some(256) }))
+            .contains(&StorageSlot::new(1, 0, AbiType::UInt { size: Some(256) }))
     );
 
     // `address`
@@ -95,10 +95,10 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         13,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
-                    StructElement::new(0, AbiType::Number { size: Some(256) }),
+                    StructElement::new(0, AbiType::UInt { size: Some(256) }),
                     StructElement::new(256, AbiType::Address),
                     StructElement::new(416, AbiType::Number { size: Some(8) }),
                     StructElement::new(512, AbiType::Bytes { length: Some(32) }),
@@ -135,45 +135,45 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             .contains(&StorageSlot::new(15, 0, AbiType::Number { size: None }))
     );
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(number256 => uint256)`
+    // `mapping(uint256 => uint256)`
     assert!(layout.slots().contains(&StorageSlot::new(
         16,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: Some(256) }),
         }
     )));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
     // numberUnknown)`
     assert!(layout.slots().contains(&StorageSlot::new(
         17,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::Number { size: None }),
         }
     )));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
     // uintUnknown)`
     assert!(layout.slots().contains(&StorageSlot::new(
         18,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     )));
 
     // `mapping(uint256 => mapping(uint256 => uint256))` but we infer
-    // `mapping(number256 => mapping(bytes32 => uint256))`
+    // `mapping(uint256 => mapping(bytes32 => uint256))`
     assert!(layout.slots().contains(&StorageSlot::new(
         19,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::Mapping {
                 key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
@@ -181,43 +181,42 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(number256 => uint256))`
+    // `mapping(address => mapping(uint256 => uint256))`
     assert!(layout.slots().contains(&StorageSlot::new(
         20,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
             }),
         }
     )));
 
     // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(number256 => uintUnknown))`
+    // `mapping(address => mapping(uint256 => uintUnknown))`
     assert!(layout.slots().contains(&StorageSlot::new(
         21,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: None }),
             }),
         }
     )));
 
     // `mapping(address => mapping(uint256 => mapping(uint256 => uint256)))` but we
-    // infer `mapping(address => mapping(number256 => mapping(bytes32 => uint256))`
+    // infer `mapping(address => mapping(uint256 => mapping(bytes32 => uint256))`
     assert!(layout.slots().contains(&StorageSlot::new(
         22,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::Mapping {
                     key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
                     value_type: Box::new(AbiType::UInt { size: Some(256) }),
@@ -226,29 +225,28 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(number256 => uint256))`
+    // `mapping(address => mapping(uint256 => uint256))`
     assert!(layout.slots().contains(&StorageSlot::new(
         23,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
             }),
         }
     )));
 
     // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(number256 => struct))`
+    // `mapping(address => mapping(uint256 => struct))`
     assert!(layout.slots().contains(&StorageSlot::new(
         24,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::Struct {
                     elements: vec![
                         StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -260,14 +258,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     )));
 
     // `mapping(address => mapping(uint256 => bool))` but we infer
-    // `mapping(address => mapping(number256 => struct))`
+    // `mapping(address => mapping(uint256 => struct(number8, bytes31)))`
     assert!(layout.slots().contains(&StorageSlot::new(
         25,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::Number { size: Some(256) }),
+                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::Struct {
                     elements: vec![
                         StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -328,12 +326,12 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(uint256 => bool)` but we infer `mapping(number256 => struct)`
+    // `mapping(uint256 => bool)` but we infer `mapping(uint256 => struct)`
     assert!(layout.slots().contains(&StorageSlot::new(
         31,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
                     StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -343,24 +341,24 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     )));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
     // uintUnknown)`
     assert!(layout.slots().contains(&StorageSlot::new(
         32,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     )));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
     // uintUnknown)`
     assert!(layout.slots().contains(&StorageSlot::new(
         33,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Number { size: Some(256) }),
+            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     )));


### PR DESCRIPTION
# Summary

Previously dynamic arrays could only be discovered at the top level (as constant storage slots). Now we are capable of discovering them under non-constant slots, and hence inside structs.

Closes #73 

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
