### PR TITLE
Revive the inference rule tests

### DIFF
--- a/src/inference/lift/dynamic_array_access.rs
+++ b/src/inference/lift/dynamic_array_access.rs
@@ -103,31 +103,25 @@ mod test {
         let input_value = RSV::new_value(0, Provenance::Synthetic);
         let input_index = RSV::new_value(1, Provenance::Synthetic);
         let input_slot = RSV::new_known_value(3, KnownWord::from(3), Provenance::Synthetic, None);
-        let hash = RSV::new(
+        let hash = RSV::new_synthetic(
             2,
             RSVD::Sha3 {
                 data: input_slot.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
-        let add = RSV::new(
+        let add = RSV::new_synthetic(
             3,
             RSVD::Add {
                 left:  hash,
                 right: input_index.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
-        let store = RSV::new(
+        let store = RSV::new_synthetic(
             4,
             RSVD::StorageWrite {
                 key:   add,
                 value: input_value.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
 
         // Run the pass

--- a/src/inference/lift/mapping_index.rs
+++ b/src/inference/lift/mapping_index.rs
@@ -92,15 +92,13 @@ mod test {
     fn resolves_mapping_accesses_at_top_level() -> anyhow::Result<()> {
         let input_key = RSV::new_value(0, Provenance::Synthetic);
         let input_slot = RSV::new_known_value(1, KnownWord::from(10), Provenance::Synthetic, None);
-        let concat = RSV::new(
+        let concat = RSV::new_synthetic(
             2,
             RSVD::Concat {
                 values: vec![input_key.clone(), input_slot.clone()],
             },
-            Provenance::Synthetic,
-            None,
         );
-        let hash = RSV::new(3, RSVD::Sha3 { data: concat }, Provenance::Synthetic, None);
+        let hash = RSV::new_synthetic(3, RSVD::Sha3 { data: concat });
         let slot_key = RSV::new_value(4, Provenance::Synthetic);
         let s_load = RSV::new_synthetic(
             5,
@@ -140,29 +138,20 @@ mod test {
     fn resolves_mapping_accesses_while_nested() -> anyhow::Result<()> {
         let input_key = RSV::new_value(0, Provenance::Synthetic);
         let input_slot = RSV::new_known_value(1, KnownWord::from(10), Provenance::Synthetic, None);
-        let concat = RSV::new(
+        let concat = RSV::new_synthetic(
             2,
             RSVD::Concat {
                 values: vec![input_key.clone(), input_slot.clone()],
             },
-            Provenance::Synthetic,
-            None,
         );
-        let inner_hash = RSV::new(3, RSVD::Sha3 { data: concat }, Provenance::Synthetic, None);
-        let outer_concat = RSV::new(
+        let inner_hash = RSV::new_synthetic(3, RSVD::Sha3 { data: concat });
+        let outer_concat = RSV::new_synthetic(
             4,
             RSVD::Concat {
                 values: vec![input_key.clone(), inner_hash],
             },
-            Provenance::Synthetic,
-            None,
         );
-        let outer_hash = RSV::new(
-            5,
-            RSVD::Sha3 { data: outer_concat },
-            Provenance::Synthetic,
-            None,
-        );
+        let outer_hash = RSV::new_synthetic(5, RSVD::Sha3 { data: outer_concat });
         let slot_key = RSV::new_value(6, Provenance::Synthetic);
         let s_store = RSV::new_synthetic(
             7,

--- a/src/inference/lift/recognise_hashed_slots.rs
+++ b/src/inference/lift/recognise_hashed_slots.rs
@@ -23,7 +23,7 @@ pub const SLOT_COUNT: usize = 10000;
 ///
 /// becomes
 ///
-/// sha3(preimage(C)
+/// sha3(preimage(C))
 /// ```
 ///
 /// where:

--- a/src/inference/lift/storage_slots.rs
+++ b/src/inference/lift/storage_slots.rs
@@ -116,15 +116,13 @@ mod test {
         let slot_index_constant =
             RSV::new_known_value(0, KnownWord::from(7), Provenance::Synthetic, None);
         let mapping_key = RSV::new_value(1, Provenance::Synthetic);
-        let mapping_access = RSV::new(
+        let mapping_access = RSV::new_synthetic(
             2,
             RSVD::MappingIndex {
                 key:        mapping_key.clone(),
                 slot:       slot_index_constant.clone(),
                 projection: None,
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -156,25 +154,21 @@ mod test {
         let slot_index_constant =
             RSV::new_known_value(0, KnownWord::from(7), Provenance::Synthetic, None);
         let mapping_key = RSV::new_value(1, Provenance::Synthetic);
-        let mapping_access = RSV::new(
+        let mapping_access = RSV::new_synthetic(
             2,
             RSVD::MappingIndex {
                 key:        mapping_key.clone(),
                 slot:       slot_index_constant.clone(),
                 projection: None,
             },
-            Provenance::Synthetic,
-            None,
         );
         let outer_key = RSV::new_value(1, Provenance::Synthetic);
-        let write = RSV::new(
+        let write = RSV::new_synthetic(
             7,
             RSVD::StorageWrite {
                 key:   outer_key.clone(),
                 value: mapping_access,
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -217,14 +211,12 @@ mod test {
     fn lifts_storage_slots_in_s_stores() -> anyhow::Result<()> {
         let storage_key = RSV::new_known_value(0, KnownWord::from(1), Provenance::Synthetic, None);
         let storage_value = RSV::new_value(1, Provenance::Synthetic);
-        let storage_store = RSV::new(
+        let storage_store = RSV::new_synthetic(
             2,
             RSVD::StorageWrite {
                 key:   storage_key.clone(),
                 value: storage_value.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -248,14 +240,12 @@ mod test {
     fn lifts_storage_slots_in_dyn_arrays() -> anyhow::Result<()> {
         let input_slot = RSV::new_value(0, Provenance::Synthetic);
         let input_index = RSV::new_value(1, Provenance::Synthetic);
-        let dyn_array = RSV::new(
+        let dyn_array = RSV::new_synthetic(
             2,
             RSVD::DynamicArrayIndex {
                 slot:  input_slot.clone(),
                 index: input_index.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -280,24 +270,20 @@ mod test {
 
     #[test]
     fn does_not_re_wrap_slots_in_mappings() -> anyhow::Result<()> {
-        let input_slot = RSV::new(
+        let input_slot = RSV::new_synthetic(
             0,
             RSVD::StorageSlot {
                 key: RSV::new_value(1, Provenance::Synthetic),
             },
-            Provenance::Synthetic,
-            None,
         );
         let mapping_key = RSV::new_value(1, Provenance::Synthetic);
-        let mapping_access = RSV::new(
+        let mapping_access = RSV::new_synthetic(
             2,
             RSVD::MappingIndex {
                 key:        mapping_key.clone(),
                 slot:       input_slot.clone(),
                 projection: None,
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -321,23 +307,19 @@ mod test {
 
     #[test]
     fn does_not_re_wrap_slots_in_s_stores() -> anyhow::Result<()> {
-        let input_slot = RSV::new(
+        let input_slot = RSV::new_synthetic(
             0,
             RSVD::StorageSlot {
                 key: RSV::new_value(1, Provenance::Synthetic),
             },
-            Provenance::Synthetic,
-            None,
         );
         let storage_value = RSV::new_value(1, Provenance::Synthetic);
-        let storage_store = RSV::new(
+        let storage_store = RSV::new_synthetic(
             2,
             RSVD::StorageWrite {
                 key:   input_slot.clone(),
                 value: storage_value.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();
@@ -356,23 +338,19 @@ mod test {
 
     #[test]
     fn does_not_re_wrap_slots_in_dyn_arrays() -> anyhow::Result<()> {
-        let input_slot = RSV::new(
+        let input_slot = RSV::new_synthetic(
             0,
             RSVD::StorageSlot {
                 key: RSV::new_value(1, Provenance::Synthetic),
             },
-            Provenance::Synthetic,
-            None,
         );
         let input_index = RSV::new_value(1, Provenance::Synthetic);
-        let dyn_array = RSV::new(
+        let dyn_array = RSV::new_synthetic(
             2,
             RSVD::DynamicArrayIndex {
                 slot:  input_slot.clone(),
                 index: input_index.clone(),
             },
-            Provenance::Synthetic,
-            None,
         );
 
         let state = InferenceState::empty();

--- a/src/inference/rule/arithmetic_operations.rs
+++ b/src/inference/rule/arithmetic_operations.rs
@@ -63,305 +63,324 @@ impl InferenceRule for ArithmeticOperationRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::TE,
-//             rule::{arithmetic_operations::ArithmeticOperationRule,
-// InferenceRule},             state::InferenceState,
-//         },
-//         vm::value::{known::KnownWord, Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_equations_for_add() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let add = RSV::new(
-//             2,
-//             RSVD::Add {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [left_ty, right_ty, add_ty] = state.register_many([left, right,
-// add.clone()]);         let tc_input = state.value_unchecked(&add_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(add_ty).contains(&TE::numeric(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_multiply() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let mul = RSV::new(
-//             2,
-//             RSVD::Add {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [left_ty, right_ty, mul_ty] = state.register_many([left, right,
-// mul.clone()]);         let tc_input = state.value_unchecked(&mul_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(mul_ty).contains(&TE::numeric(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_subtract() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let sub = RSV::new(
-//             2,
-//             RSVD::Add {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [left_ty, right_ty, sub_ty] = state.register_many([left, right,
-// sub.clone()]);         let tc_input = state.value_unchecked(&sub_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(sub_ty).contains(&TE::numeric(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_divide() -> anyhow::Result<()> {
-//         // Create some values
-//         let dividend = RSV::new_value(0, Provenance::Synthetic);
-//         let divisor = RSV::new_value(1, Provenance::Synthetic);
-//         let div = RSV::new(
-//             2,
-//             RSVD::Divide {
-//                 dividend: dividend.clone(),
-//                 divisor:  divisor.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [dividend_ty, divisor_ty, div_ty] =
-//             state.register_many([dividend, divisor, div.clone()]);
-//         let tc_input = state.value_unchecked(div_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(dividend_ty).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(divisor_ty).
-// contains(&TE::unsigned_word(None)));         assert!(state.
-// inferences(div_ty).contains(&TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_signed_divide() -> anyhow::Result<()> {
-//         // Create some values
-//         let dividend = RSV::new_value(0, Provenance::Synthetic);
-//         let divisor = RSV::new_value(1, Provenance::Synthetic);
-//         let div = RSV::new(
-//             2,
-//             RSVD::SignedDivide {
-//                 dividend: dividend.clone(),
-//                 divisor:  divisor.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [dividend_ty, divisor_ty, div_ty] =
-//             state.register_many([dividend, divisor, div.clone()]);
-//         let tc_input = state.value_unchecked(div_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(dividend_ty).contains(&
-// TE::signed_word(None)));         assert!(state.inferences(divisor_ty).
-// contains(&TE::signed_word(None)));         assert!(state.inferences(div_ty).
-// contains(&TE::signed_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_modulo() -> anyhow::Result<()> {
-//         // Create some values
-//         let dividend = RSV::new_value(0, Provenance::Synthetic);
-//         let divisor = RSV::new_value(1, Provenance::Synthetic);
-//         let modulo = RSV::new(
-//             2,
-//             RSVD::Modulo {
-//                 dividend: dividend.clone(),
-//                 divisor:  divisor.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [dividend_ty, divisor_ty, div_ty] =
-//             state.register_many([dividend, divisor, modulo.clone()]);
-//         let tc_input = state.value_unchecked(div_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(dividend_ty).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(divisor_ty).
-// contains(&TE::unsigned_word(None)));         assert!(state.
-// inferences(div_ty).contains(&TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_signed_modulo() -> anyhow::Result<()> {
-//         // Create some values
-//         let dividend = RSV::new_value(0, Provenance::Synthetic);
-//         let divisor = RSV::new_value(1, Provenance::Synthetic);
-//         let modulo = RSV::new(
-//             2,
-//             RSVD::SignedModulo {
-//                 dividend: dividend.clone(),
-//                 divisor:  divisor.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [dividend_ty, divisor_ty, div_ty] =
-//             state.register_many([dividend, divisor, modulo.clone()]);
-//         let tc_input = state.value_unchecked(div_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(dividend_ty).contains(&
-// TE::signed_word(None)));         assert!(state.inferences(divisor_ty).
-// contains(&TE::signed_word(None)));         assert!(state.inferences(div_ty).
-// contains(&TE::signed_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_exp() -> anyhow::Result<()> {
-//         // Create some values
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let exponent = RSV::new_value(1, Provenance::Synthetic);
-//         let exp = RSV::new(
-//             2,
-//             RSVD::Exp {
-//                 value:    value.clone(),
-//                 exponent: exponent.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [value_ty, exponent_ty, exp_ty] = state.register_many([value,
-// exponent, exp.clone()]);         let tc_input =
-// state.value_unchecked(exp_ty).clone();         ArithmeticOperationRule.
-// infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(value_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(exponent_ty).contains(&TE::numeric(None)));
-//         assert!(state.inferences(exp_ty).contains(&TE::numeric(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_sign_extend_with_known_size() ->
-// anyhow::Result<()> {         // Create some values
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let size = RSV::new_known_value(1, KnownWord::from(128),
-// Provenance::Synthetic);         let ext = RSV::new(
-//             2,
-//             RSVD::SignExtend {
-//                 value: value.clone(),
-//                 size:  size.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [value_ty, size_ty, ext_ty] = state.register_many([value, size,
-// ext.clone()]);         let tc_input = state.value_unchecked(ext_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(size_ty).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(ext_ty).
-// contains(&TE::signed_word(Some(128))));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_sign_extend_with_unknown_size() ->
-// anyhow::Result<()> {         // Create some values
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let size = RSV::new_value(1, Provenance::Synthetic);
-//         let ext = RSV::new(
-//             2,
-//             RSVD::SignExtend {
-//                 value: value.clone(),
-//                 size:  size.clone(),
-//             },
-//             Provenance::Synthetic,
-//         );
-//
-//         // Register them with the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [value_ty, size_ty, ext_ty] = state.register_many([value, size,
-// ext.clone()]);         let tc_input = state.value_unchecked(ext_ty).clone();
-//         ArithmeticOperationRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(size_ty).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(ext_ty).
-// contains(&TE::signed_word(None)));
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{arithmetic_operations::ArithmeticOperationRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{known::KnownWord, Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_add() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let add = RSV::new_synthetic(
+            2,
+            RSVD::Add {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let add_ty = state.register(add);
+        let tc_input = state.value_unchecked(add_ty).clone();
+        let [left_ty, right_ty] = match tc_input.data() {
+            TCSVD::Add { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(add_ty).contains(&TE::numeric(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_multiply() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let mul = RSV::new_synthetic(
+            2,
+            RSVD::Multiply {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let mul_ty = state.register(mul);
+        let tc_input = state.value_unchecked(mul_ty).clone();
+        let [left_ty, right_ty] = match tc_input.data() {
+            TCSVD::Multiply { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(mul_ty).contains(&TE::numeric(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_subtract() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let sub = RSV::new_synthetic(
+            2,
+            RSVD::Subtract {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let sub_ty = state.register(sub);
+        let tc_input = state.value_unchecked(sub_ty).clone();
+        let [left_ty, right_ty] = match tc_input.data() {
+            TCSVD::Subtract { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(right_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(sub_ty).contains(&TE::numeric(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_divide() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = RSV::new_value(0, Provenance::Synthetic);
+        let divisor = RSV::new_value(1, Provenance::Synthetic);
+        let div = RSV::new_synthetic(
+            2,
+            RSVD::Divide {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let div_ty = state.register(div);
+        let tc_input = state.value_unchecked(div_ty).clone();
+        let [dividend_ty, divisor_ty] = match tc_input.data() {
+            TCSVD::Divide { dividend, divisor } => [dividend.type_var(), divisor.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_signed_divide() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = RSV::new_value(0, Provenance::Synthetic);
+        let divisor = RSV::new_value(1, Provenance::Synthetic);
+        let div = RSV::new_synthetic(
+            2,
+            RSVD::SignedDivide {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let div_ty = state.register(div);
+        let tc_input = state.value_unchecked(div_ty).clone();
+        let [dividend_ty, divisor_ty] = match tc_input.data() {
+            TCSVD::SignedDivide { dividend, divisor } => [dividend.type_var(), divisor.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_modulo() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = RSV::new_value(0, Provenance::Synthetic);
+        let divisor = RSV::new_value(1, Provenance::Synthetic);
+        let modulo = RSV::new_synthetic(
+            2,
+            RSVD::Modulo {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let div_ty = state.register(modulo);
+        let tc_input = state.value_unchecked(div_ty).clone();
+        let [dividend_ty, divisor_ty] = match tc_input.data() {
+            TCSVD::Modulo { dividend, divisor } => [dividend.type_var(), divisor.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_signed_modulo() -> anyhow::Result<()> {
+        // Create some values
+        let dividend = RSV::new_value(0, Provenance::Synthetic);
+        let divisor = RSV::new_value(1, Provenance::Synthetic);
+        let modulo = RSV::new_synthetic(
+            2,
+            RSVD::SignedModulo {
+                dividend: dividend.clone(),
+                divisor:  divisor.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let div_ty = state.register(modulo);
+        let tc_input = state.value_unchecked(div_ty).clone();
+        let [dividend_ty, divisor_ty] = match tc_input.data() {
+            TCSVD::SignedModulo { dividend, divisor } => [dividend.type_var(), divisor.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(dividend_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(divisor_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(div_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_exp() -> anyhow::Result<()> {
+        // Create some values
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let exponent = RSV::new_value(1, Provenance::Synthetic);
+        let exp = RSV::new_synthetic(
+            2,
+            RSVD::Exp {
+                value:    value.clone(),
+                exponent: exponent.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let exp_ty = state.register(exp);
+        let tc_input = state.value_unchecked(exp_ty).clone();
+        let [value_ty, exponent_ty] = match tc_input.data() {
+            TCSVD::Exp { value, exponent } => [value.type_var(), exponent.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(exponent_ty).contains(&TE::numeric(None)));
+        assert!(state.inferences(exp_ty).contains(&TE::numeric(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sign_extend_with_known_size() -> anyhow::Result<()> {
+        // Create some values
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let size = RSV::new_known_value(1, KnownWord::from(128), Provenance::Synthetic, None);
+        let ext = RSV::new_synthetic(
+            2,
+            RSVD::SignExtend {
+                value: value.clone(),
+                size:  size.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let ext_ty = state.register(ext.clone());
+        let tc_input = state.value_unchecked(ext_ty).clone();
+        let [value_ty, size_ty] = match tc_input.data() {
+            TCSVD::SignExtend { value, size } => [value.type_var(), size.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(size_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(ext_ty).contains(&TE::signed_word(Some(128))));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sign_extend_with_unknown_size() -> anyhow::Result<()> {
+        // Create some values
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let size = RSV::new_value(1, Provenance::Synthetic);
+        let ext = RSV::new_synthetic(
+            2,
+            RSVD::SignExtend {
+                value: value.clone(),
+                size:  size.clone(),
+            },
+        );
+
+        // Register them with the state and run inference
+        let mut state = InferenceState::empty();
+        let ext_ty = state.register(ext.clone());
+        let tc_input = state.value_unchecked(ext_ty).clone();
+        let [value_ty, size_ty] = match tc_input.data() {
+            TCSVD::SignExtend { value, size } => [value.type_var(), size.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ArithmeticOperationRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_ty).contains(&TE::signed_word(None)));
+        assert!(state.inferences(size_ty).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(ext_ty).contains(&TE::signed_word(None)));
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/boolean_operations.rs
+++ b/src/inference/rule/boolean_operations.rs
@@ -53,290 +53,318 @@ impl InferenceRule for BooleanOpsRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::TE,
-//             rule::{boolean_operations::BooleanOpsRule, InferenceRule},
-//             state::InferenceState,
-//         },
-//         vm::value::{Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_equations_for_lt() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::LessThan {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(right_tv).
-// contains(&TE::unsigned_word(None)));         assert!(state.
-// inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_gt() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::GreaterThan {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(right_tv).
-// contains(&TE::unsigned_word(None)));         assert!(state.
-// inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_slt() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::SignedLessThan {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_sgt() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::SignedGreaterThan {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_eq() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::Equals {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_is_zero() -> anyhow::Result<()> {
-//         // Create some values
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::IsZero {
-//                 number: value.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [value_tv, operator_tv] = state.register_many([value,
-// operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::numeric(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bool()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_and() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::And {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_or() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::Or {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_xor() -> anyhow::Result<()> {
-//         // Create some values
-//         let left = RSV::new_value(0, Provenance::Synthetic);
-//         let right = RSV::new_value(1, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::Xor {
-//                 left:  left.clone(),
-//                 right: right.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [left_tv, right_tv, operator_tv] = state.register_many([left,
-// right, operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_not() -> anyhow::Result<()> {
-//         // Create some values
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             2,
-//             RSVD::Not {
-//                 value: value.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [value_tv, operator_tv] = state.register_many([value,
-// operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         BooleanOpsRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::bytes(None)));
-//         assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{boolean_operations::BooleanOpsRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_lt() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::LessThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::LessThan { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gt() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::GreaterThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::GreaterThan { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_slt() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::SignedLessThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::SignedLessThan { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_sgt() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::SignedGreaterThan {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::SignedGreaterThan { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(right_tv).contains(&TE::signed_word(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_eq() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::Equals {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::Equals { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_is_zero() -> anyhow::Result<()> {
+        // Create some values
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::IsZero {
+                number: value.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let value_tv = match tc_input.data() {
+            TCSVD::IsZero { number } => number.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::numeric(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bool()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_and() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::And {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::And { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_or() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::Or {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::Or { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_xor() -> anyhow::Result<()> {
+        // Create some values
+        let left = RSV::new_value(0, Provenance::Synthetic);
+        let right = RSV::new_value(1, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::Xor {
+                left:  left.clone(),
+                right: right.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [left_tv, right_tv] = match tc_input.data() {
+            TCSVD::Xor { left, right } => [left.type_var(), right.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(left_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(right_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_not() -> anyhow::Result<()> {
+        // Create some values
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            2,
+            RSVD::Not {
+                value: value.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let value_tv = match tc_input.data() {
+            TCSVD::Not { value } => value.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        BooleanOpsRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::bytes(None)));
+        assert!(state.inferences(operator_tv).contains(&TE::bytes(None)));
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/environment_opcodes.rs
+++ b/src/inference/rule/environment_opcodes.rs
@@ -48,329 +48,325 @@ impl InferenceRule for EnvironmentCodesRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::TE,
-//             rule::{environment_opcodes::EnvironmentCodesRule, InferenceRule},
-//             state::InferenceState,
-//         },
-//         vm::value::{Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_equations_for_address() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::Address);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::address()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_origin() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::Origin);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::address()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_caller() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::Caller);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::address()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_coin_base() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::CoinBase);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&TE::address()));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_balance() -> anyhow::Result<()> {
-//         // Create a value
-//         let address = RSV::new_value(0, Provenance::Synthetic);
-//         let value = RSV::new_synthetic(
-//             1,
-//             RSVD::Balance {
-//                 address: address.clone(),
-//             },
-//         );
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [value_tv, address_tv] = state.register_many([value.clone(),
-// address]);         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(address_tv).contains(&TE::address()));
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_call_value() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::CallValue);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_gas_price() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::GasPrice);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_block_timestamp() -> anyhow::Result<()>
-// {         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::BlockTimestamp);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_block_number() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::BlockNumber);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_prevrandao() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::Prevrandao);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_gas_limit() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::GasLimit);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_chain_id() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::ChainId);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_self_balance() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::SelfBalance);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_base_fee() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::BaseFee);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_gas() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::Gas);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_call_data_size() -> anyhow::Result<()> {
-//         // Create a value
-//         let value = RSV::new_synthetic(0, RSVD::CallDataSize);
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let value_tv = state.register(value.clone());
-//         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(value_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_self_destruct() -> anyhow::Result<()> {
-//         // Create a value
-//         let address = RSV::new_value(0, Provenance::Synthetic);
-//         let value = RSV::new_synthetic(
-//             1,
-//             RSVD::SelfDestruct {
-//                 target: address.clone(),
-//             },
-//         );
-//
-//         // Create the state and run inference
-//         let mut state = InferenceState::empty();
-//         let [value_tv, address_tv] = state.register_many([value.clone(),
-// address]);         let tc_input = state.value_unchecked(value_tv).clone();
-//         EnvironmentCodesRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we get the right equations
-//         assert!(state.inferences(address_tv).contains(&TE::address()));
-//         assert!(state.inferences(value_tv).is_empty());
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{environment_opcodes::EnvironmentCodesRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_address() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::Address);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_origin() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::Origin);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_caller() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::Caller);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_coin_base() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::CoinBase);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::address()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_balance() -> anyhow::Result<()> {
+        // Create a value
+        let address = RSV::new_value(0, Provenance::Synthetic);
+        let value = RSV::new_synthetic(
+            1,
+            RSVD::Balance {
+                address: address.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value);
+        let tc_input = state.value_unchecked(value_tv).clone();
+        let address_tv = match tc_input.data() {
+            TCSVD::Balance { address } => address.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_call_value() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::CallValue);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas_price() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::GasPrice);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_block_timestamp() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::BlockTimestamp);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_block_number() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::BlockNumber);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_prevrandao() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::Prevrandao);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas_limit() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::GasLimit);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_chain_id() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::ChainId);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_self_balance() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::SelfBalance);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_base_fee() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::BaseFee);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_gas() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::Gas);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_call_data_size() -> anyhow::Result<()> {
+        // Create a value
+        let value = RSV::new_synthetic(0, RSVD::CallDataSize);
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value.clone());
+        let tc_input = state.value_unchecked(value_tv).clone();
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(value_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_self_destruct() -> anyhow::Result<()> {
+        // Create a value
+        let address = RSV::new_value(0, Provenance::Synthetic);
+        let value = RSV::new_synthetic(
+            1,
+            RSVD::SelfDestruct {
+                target: address.clone(),
+            },
+        );
+
+        // Create the state and run inference
+        let mut state = InferenceState::empty();
+        let value_tv = state.register(value);
+        let tc_input = state.value_unchecked(value_tv).clone();
+        let address_tv = match tc_input.data() {
+            TCSVD::SelfDestruct { target } => target.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        EnvironmentCodesRule.infer(&tc_input, &mut state)?;
+
+        // Check that we get the right equations
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(value_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/ext_code.rs
+++ b/src/inference/rule/ext_code.rs
@@ -53,72 +53,80 @@ impl InferenceRule for ExtCodeRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::TE,
-//             rule::{ext_code::ExtCodeRule, InferenceRule},
-//             state::InferenceState,
-//         },
-//         vm::value::{Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_equations_for_ext_code_size() -> anyhow::Result<()> {
-//         // Create some values
-//         let address = RSV::new_value(0, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             1,
-//             RSVD::ExtCodeSize {
-//                 address: address.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [address_tv, operator_tv] = state.register_many([address,
-// operator.clone()]);         let tc_input =
-// state.value_unchecked(operator_tv).clone();         ExtCodeRule.infer(&
-// tc_input, &mut state)?;
-//
-//         // Check we get the equations we want
-//         assert!(state.inferences(address_tv).contains(&TE::address()));
-//         assert!(state.inferences(operator_tv).contains(&
-// TE::unsigned_word(None)));
-//
-//         Ok(())
-//     }
-//
-//     #[test]
-//     fn creates_correct_equations_for_ext_code_copy() -> anyhow::Result<()> {
-//         // Create some values
-//         let address = RSV::new_value(0, Provenance::Synthetic);
-//         let offset = RSV::new_value(1, Provenance::Synthetic);
-//         let size = RSV::new_value(2, Provenance::Synthetic);
-//         let operator = RSV::new_synthetic(
-//             3,
-//             RSVD::ExtCodeCopy {
-//                 address: address.clone(),
-//                 offset:  offset.clone(),
-//                 size:    size.clone(),
-//             },
-//         );
-//
-//         // Create the state and run the rule
-//         let mut state = InferenceState::empty();
-//         let [address_tv, offset_tv, size_tv, operator_tv] =
-//             state.register_many([address, offset, size, operator.clone()]);
-//         let tc_input = state.value_unchecked(operator_tv).clone();
-//         ExtCodeRule.infer(&tc_input, &mut state)?;
-//
-//         // Check we get the equations we want
-//         assert!(state.inferences(address_tv).contains(&TE::address()));
-//         assert!(state.inferences(offset_tv).contains(&
-// TE::unsigned_word(None)));         assert!(state.inferences(size_tv).
-// contains(&TE::unsigned_word(None)));         assert!(state.
-// inferences(operator_tv).is_empty());
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{ext_code::ExtCodeRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_for_ext_code_size() -> anyhow::Result<()> {
+        // Create some values
+        let address = RSV::new_value(0, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            1,
+            RSVD::ExtCodeSize {
+                address: address.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let address_tv = match tc_input.data() {
+            TCSVD::ExtCodeSize { address } => address.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        ExtCodeRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the equations we want
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(operator_tv).contains(&TE::unsigned_word(None)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn creates_correct_equations_for_ext_code_copy() -> anyhow::Result<()> {
+        // Create some values
+        let address = RSV::new_value(0, Provenance::Synthetic);
+        let offset = RSV::new_value(1, Provenance::Synthetic);
+        let size = RSV::new_value(2, Provenance::Synthetic);
+        let operator = RSV::new_synthetic(
+            3,
+            RSVD::ExtCodeCopy {
+                address: address.clone(),
+                offset:  offset.clone(),
+                size:    size.clone(),
+            },
+        );
+
+        // Create the state and run the rule
+        let mut state = InferenceState::empty();
+        let operator_tv = state.register(operator);
+        let tc_input = state.value_unchecked(operator_tv).clone();
+        let [address_tv, offset_tv, size_tv] = match tc_input.data() {
+            TCSVD::ExtCodeCopy {
+                address,
+                offset,
+                size,
+            } => [address.type_var(), offset.type_var(), size.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        ExtCodeRule.infer(&tc_input, &mut state)?;
+
+        // Check we get the equations we want
+        assert!(state.inferences(address_tv).contains(&TE::address()));
+        assert!(state.inferences(offset_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(size_tv).contains(&TE::unsigned_word(None)));
+        assert!(state.inferences(operator_tv).is_empty());
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/masked_word.rs
+++ b/src/inference/rule/masked_word.rs
@@ -48,52 +48,54 @@ impl InferenceRule for MaskedWordRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::{Span, WordUse, TE},
-//             rule::{masked_word::MaskedWordRule, InferenceRule},
-//             state::InferenceState,
-//         },
-//         vm::value::{Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_inference_equations() -> anyhow::Result<()> {
-//         // Create the values to run inference on
-//         let value = RSV::new_value(0, Provenance::Synthetic);
-//         let mask = RSV::new_synthetic(
-//             1,
-//             RSVD::SubWord {
-//                 value:  value.clone(),
-//                 offset: 64,
-//                 size:   128,
-//             },
-//         );
-//
-//         // Register them in the state
-//         let mut state = InferenceState::empty();
-//         let [value_tv, mask_tv] = state.register_many([value, mask.clone()]);
-//
-//         // Run the inference rule
-//         let tc_input = state.value_unchecked(mask_tv).clone();
-//         MaskedWordRule.infer(&tc_input, &mut state)?;
-//
-//         // Check that we end up with the correct equations
-//         assert_eq!(state.inferences(value_tv).len(), 1);
-//         assert!(
-//             state
-//                 .inferences(value_tv)
-//                 .contains(&TE::packed_of(vec![Span::new(mask_tv, 64, 128)]))
-//         );
-//         assert_eq!(state.inferences(mask_tv).len(), 1);
-//         assert!(
-//             state
-//                 .inferences(mask_tv)
-//                 .contains(&TE::word(Some(128), WordUse::Bytes))
-//         );
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::{Span, WordUse, TE},
+            rule::{masked_word::MaskedWordRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_inference_equations() -> anyhow::Result<()> {
+        // Create the values to run inference on
+        let value = RSV::new_value(0, Provenance::Synthetic);
+        let mask = RSV::new_synthetic(
+            1,
+            RSVD::SubWord {
+                value:  value.clone(),
+                offset: 64,
+                size:   128,
+            },
+        );
+
+        // Register them in the state
+        let mut state = InferenceState::empty();
+        let mask_tv = state.register(mask);
+        let tc_input = state.value_unchecked(mask_tv).clone();
+        let value_tv = match tc_input.data() {
+            TCSVD::SubWord { value, .. } => value.type_var(),
+            _ => panic!("Incorrect payload"),
+        };
+        MaskedWordRule.infer(&tc_input, &mut state)?;
+
+        // Check that we end up with the correct equations
+        assert_eq!(state.inferences(value_tv).len(), 1);
+        assert!(
+            state
+                .inferences(value_tv)
+                .contains(&TE::packed_of(vec![Span::new(mask_tv, 64, 128)]))
+        );
+        assert_eq!(state.inferences(mask_tv).len(), 1);
+        assert!(
+            state
+                .inferences(mask_tv)
+                .contains(&TE::word(Some(128), WordUse::Bytes))
+        );
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/packed_encoding.rs
+++ b/src/inference/rule/packed_encoding.rs
@@ -44,55 +44,59 @@ impl InferenceRule for PackedEncodingRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::{Span, TE},
-//             rule::{packed_encoding::PackedEncodingRule, InferenceRule},
-//             state::InferenceState,
-//         },
-//         vm::value::{PackedSpan, Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_expressions_in_typing_state() -> anyhow::Result<()> {
-//         // Create the expressions to be typed
-//         let span_1_value = RSV::new_value(0, Provenance::Synthetic);
-//         let span_2_value = RSV::new_value(1, Provenance::Synthetic);
-//         let span_3_value = RSV::new_value(2, Provenance::Synthetic);
-//         let packed = RSV::new_synthetic(
-//             3,
-//             RSVD::Packed {
-//                 elements: vec![
-//                     PackedSpan::new(0, 64, span_1_value.clone()),
-//                     PackedSpan::new(128, 32, span_2_value.clone()),
-//                     PackedSpan::new(192, 16, span_3_value.clone()),
-//                 ],
-//             },
-//         );
-//
-//         // Register these in the typing state
-//         let mut state = InferenceState::empty();
-//         let [span_1_tv, span_2_tv, span_3_tv, packed_tv] =
-//             state.register_many([span_1_value, span_2_value, span_3_value,
-// packed.clone()]);
-//
-//         // Run the rule and check things make sense
-//         let tc_input = state.value_unchecked(packed_tv).clone();
-//         PackedEncodingRule.infer(&tc_input, &mut state)?;
-//
-//         assert!(state.inferences(span_1_tv).is_empty());
-//         assert!(state.inferences(span_2_tv).is_empty());
-//         assert!(state.inferences(span_3_tv).is_empty());
-//
-//         assert_eq!(state.inferences(packed_tv).len(), 1);
-//         assert!(state.inferences(packed_tv).contains(&TE::packed_of(vec![
-//             Span::new(span_1_tv, 0, 64),
-//             Span::new(span_2_tv, 128, 32),
-//             Span::new(span_3_tv, 192, 16),
-//         ])));
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::{Span, TE},
+            rule::{packed_encoding::PackedEncodingRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{PackedSpan, Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_expressions_in_typing_state() -> anyhow::Result<()> {
+        // Create the expressions to be typed
+        let span_1_value = RSV::new_value(0, Provenance::Synthetic);
+        let span_2_value = RSV::new_value(1, Provenance::Synthetic);
+        let span_3_value = RSV::new_value(2, Provenance::Synthetic);
+        let packed = RSV::new_synthetic(
+            3,
+            RSVD::Packed {
+                elements: vec![
+                    PackedSpan::new(0, 64, span_1_value.clone()),
+                    PackedSpan::new(128, 32, span_2_value.clone()),
+                    PackedSpan::new(192, 16, span_3_value.clone()),
+                ],
+            },
+        );
+
+        // Register these in the typing state
+        let mut state = InferenceState::empty();
+        let packed_tv = state.register(packed.clone());
+        let tc_input = state.value_unchecked(packed_tv).clone();
+        let [span_1_tv, span_2_tv, span_3_tv] = match tc_input.data() {
+            TCSVD::Packed { elements } => [
+                elements[0].value.type_var(),
+                elements[1].value.type_var(),
+                elements[2].value.type_var(),
+            ],
+            _ => panic!("Incorrect payload"),
+        };
+        PackedEncodingRule.infer(&tc_input, &mut state)?;
+
+        assert!(state.inferences(span_1_tv).is_empty());
+        assert!(state.inferences(span_2_tv).is_empty());
+        assert!(state.inferences(span_3_tv).is_empty());
+
+        assert_eq!(state.inferences(packed_tv).len(), 1);
+        assert!(state.inferences(packed_tv).contains(&TE::packed_of(vec![
+            Span::new(span_1_tv, 0, 64),
+            Span::new(span_2_tv, 128, 32),
+            Span::new(span_3_tv, 192, 16),
+        ])));
+
+        Ok(())
+    }
+}

--- a/src/inference/rule/s_load_is_inner_types.rs
+++ b/src/inference/rule/s_load_is_inner_types.rs
@@ -42,47 +42,50 @@ impl InferenceRule for SLoadIsInnerTypesRule {
     }
 }
 
-// #[cfg(test)]
-// mod test {
-//     use crate::{
-//         inference::{
-//             expression::TE,
-//             rule::{s_load_is_element_type::SLoadIsElementTypeRule,
-// InferenceRule},             state::InferenceState,
-//         },
-//         vm::value::{Provenance, RSV, RSVD},
-//     };
-//
-//     #[test]
-//     fn creates_correct_equations_in_state() -> anyhow::Result<()> {
-//         // Create the expressions to be typed
-//         let key = RSV::new_value(0, Provenance::Synthetic);
-//         let value = RSV::new_value(1, Provenance::Synthetic);
-//         let s_load = RSV::new_synthetic(
-//             2,
-//             RSVD::SLoad {
-//                 key:   key.clone(),
-//                 value: value.clone(),
-//             },
-//         );
-//
-//         // Register these in the state
-//         let mut state = InferenceState::empty();
-//         let [key_ty, value_ty, s_load_ty] = state.register_many([key, value,
-// s_load.clone()]);
-//
-//         // Run the inference rule and check things make sense
-//         let tc_input = state.value_unchecked(s_load_ty).clone();
-//         SLoadIsElementTypeRule.infer(&tc_input, &mut state)?;
-//
-//         assert!(state.inferences(key_ty).is_empty());
-//
-//         assert_eq!(state.inferences(value_ty).len(), 1);
-//         assert!(state.inferences(value_ty).contains(&TE::eq(s_load_ty)));
-//
-//         assert_eq!(state.inferences(s_load_ty).len(), 1);
-//         assert!(state.inferences(s_load_ty).contains(&TE::eq(value_ty)));
-//
-//         Ok(())
-//     }
-// }
+#[cfg(test)]
+mod test {
+    use crate::{
+        inference::{
+            expression::TE,
+            rule::{s_load_is_inner_types::SLoadIsInnerTypesRule, InferenceRule},
+            state::InferenceState,
+        },
+        vm::value::{Provenance, RSV, RSVD, TCSVD},
+    };
+
+    #[test]
+    fn creates_correct_equations_in_state() -> anyhow::Result<()> {
+        // Create the expressions to be typed
+        let key = RSV::new_value(0, Provenance::Synthetic);
+        let value = RSV::new_value(1, Provenance::Synthetic);
+        let s_load = RSV::new_synthetic(
+            2,
+            RSVD::SLoad {
+                key:   key.clone(),
+                value: value.clone(),
+            },
+        );
+
+        // Register these in the state
+        let mut state = InferenceState::empty();
+        let s_load_ty = state.register(s_load);
+        let tc_input = state.value_unchecked(s_load_ty).clone();
+        let [key_ty, value_ty] = match tc_input.data() {
+            TCSVD::SLoad { key, value } => [key.type_var(), value.type_var()],
+            _ => panic!("Incorrect payload"),
+        };
+        SLoadIsInnerTypesRule.infer(&tc_input, &mut state)?;
+
+        assert_eq!(state.inferences(key_ty).len(), 1);
+        assert!(state.inferences(key_ty).contains(&TE::eq(s_load_ty)));
+
+        assert_eq!(state.inferences(value_ty).len(), 1);
+        assert!(state.inferences(value_ty).contains(&TE::eq(s_load_ty)));
+
+        assert_eq!(state.inferences(s_load_ty).len(), 2);
+        assert!(state.inferences(s_load_ty).contains(&TE::eq(value_ty)));
+        assert!(state.inferences(s_load_ty).contains(&TE::eq(key_ty)));
+
+        Ok(())
+    }
+}

--- a/src/inference/state.rs
+++ b/src/inference/state.rs
@@ -59,7 +59,8 @@ impl InferenceState {
     ///
     /// This function recurses into the children of `value`, and so registers
     /// both `value` and each child node in the state with an associated type
-    /// variable. This means that you
+    /// variable. This means that you do not have easy access to the type
+    /// variables of the child nodes.
     ///
     /// # Registration Uniqueness
     ///
@@ -392,27 +393,6 @@ impl InferenceState {
 
         // Return the type variable
         new_value
-    }
-
-    /// Registers a symbolic `values` in the state, returning the associated
-    /// type variables in the corresponding order.
-    ///
-    /// If any one `value` already exists in the state, then the existing type
-    /// variable is returned. If not, a fresh type variable is associated
-    /// with the value and returned.
-    #[must_use]
-    pub fn register_many<const N: usize>(
-        &mut self,
-        values: [RuntimeBoxedVal; N],
-    ) -> [TypeVariable; N] {
-        let mut iterator = values.into_iter();
-        array::from_fn(|_| {
-            self.register(
-                iterator
-                    .next()
-                    .expect("The number of values should always be the same"),
-            )
-        })
     }
 
     /// Adds the provided `expression` to the typing expressions for the

--- a/src/inference/unification/mod.rs
+++ b/src/inference/unification/mod.rs
@@ -1238,9 +1238,12 @@ mod test {
         let elem_4 = RSV::new_value(3, Provenance::Synthetic);
         let packed_1 = RSV::new_value(4, Provenance::Synthetic);
         let packed_2 = RSV::new_value(5, Provenance::Synthetic);
-
-        let [e1_tv, e2_tv, e3_tv, e4_tv, p1_tv, p2_tv] =
-            state.register_many([elem_1, elem_2, elem_3, elem_4, packed_1, packed_2]);
+        let e1_tv = state.register(elem_1);
+        let e2_tv = state.register(elem_2);
+        let e3_tv = state.register(elem_3);
+        let e4_tv = state.register(elem_4);
+        let p1_tv = state.register(packed_1);
+        let p2_tv = state.register(packed_2);
 
         // Set up some inferences
         //
@@ -1289,8 +1292,10 @@ mod test {
         let elem_2 = RSV::new_value(1, Provenance::Synthetic);
         let elem_3 = RSV::new_value(2, Provenance::Synthetic);
         let packed_1 = RSV::new_value(3, Provenance::Synthetic);
-
-        let [e1_tv, e2_tv, e3_tv, p1_tv] = state.register_many([elem_1, elem_2, elem_3, packed_1]);
+        let e1_tv = state.register(elem_1);
+        let e2_tv = state.register(elem_2);
+        let e3_tv = state.register(elem_3);
+        let p1_tv = state.register(packed_1);
 
         // Set up some inferences
         //
@@ -1335,8 +1340,10 @@ mod test {
         let elem_2 = RSV::new_value(1, Provenance::Synthetic);
         let elem_3 = RSV::new_value(2, Provenance::Synthetic);
         let packed_1 = RSV::new_value(3, Provenance::Synthetic);
-
-        let [e1_tv, e2_tv, e3_tv, p1_tv] = state.register_many([elem_1, elem_2, elem_3, packed_1]);
+        let e1_tv = state.register(elem_1);
+        let e2_tv = state.register(elem_2);
+        let e3_tv = state.register(elem_3);
+        let p1_tv = state.register(packed_1);
 
         // Set up some inferences
         //


### PR DESCRIPTION
# Summary

Due to changes in the operation of the inference state these would fail in most cases, while still being able to compile. To that end, they were disabled to benefit working speed, in the hope that they would be fixed later.

This commit is that fix, which has worked out the best way to revive these tests and have them working again.

Closes #51 

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
