### PR TITLE
Add layouts to the additional integration tests

### DIFF
--- a/src/inference/unification/mod.rs
+++ b/src/inference/unification/mod.rs
@@ -231,7 +231,7 @@ pub fn merge(left: TE, right: TE, parent_tv: TypeVariable) -> Merge {
         // They produce bytes when certain conditions are satisfied
         (TE::Packed { types, .. }, TE::DynamicArray { .. } | TE::Bytes) => {
             if let Some(t) = types.first() {
-                if t.offset == 0 && t.size == 1 {
+                if t.offset == 0 && t.size == 1 && types.len() == 1 {
                     Merge::expression(TE::Bytes)
                 } else {
                     Merge::expression(TE::conflict(

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -32,6 +32,39 @@ impl StorageLayout {
     }
 }
 
+/// Additional utility functions to enable cleaner testing with the storage
+/// layout.
+impl StorageLayout {
+    /// Checks if the layout contains the specified slot.
+    #[must_use]
+    pub fn has_slot(&self, index: impl Into<U256Wrapper>, offset: usize, typ: AbiType) -> bool {
+        self.slots.contains(&StorageSlot::new(index, offset, typ))
+    }
+
+    /// Checks that there is no slot in the layout at the specified `index`.
+    ///
+    /// If you need to check that there is no slot specifically at an index and
+    /// offset, use the negation of [`Iterator::any`] on the result of calling
+    /// [`StorageLayout::slots`].
+    #[must_use]
+    pub fn has_no_slot_at(&self, index: impl Into<U256Wrapper>) -> bool {
+        let index = index.into();
+        !self.slots.iter().any(|s| s.index == index)
+    }
+
+    /// Gets the number of slots in the storage layout.
+    #[must_use]
+    pub fn slot_count(&self) -> usize {
+        self.slots.len()
+    }
+
+    /// Checks if the storage layout is empty (has no slots).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.slots.is_empty()
+    }
+}
+
 impl Default for StorageLayout {
     fn default() -> Self {
         let slots = Vec::new();

--- a/src/opcode/control.rs
+++ b/src/opcode/control.rs
@@ -133,7 +133,7 @@ impl Opcode for Jump {
                 vm.state()?.record_value(counter);
 
                 return match payload.payload {
-                    execution::Error::NoConcreteJumpDestination => {
+                    Error::NoConcreteJumpDestination => {
                         // If we do not have an immediate, we instead want to halt
                         // execution on this branch as it would not be valid to
                         // continue without knowing where to jump to

--- a/tests/batch_ens_lookups_no_storage_opcodes.rs
+++ b/tests/batch_ens_lookups_no_storage_opcodes.rs
@@ -18,7 +18,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // We should see no slots as this contract never uses storage opcodes.
-    assert!(layout.slots().is_empty());
+    assert!(layout.is_empty());
 
     Ok(())
 }

--- a/tests/cpu_friless_verifier.rs
+++ b/tests/cpu_friless_verifier.rs
@@ -15,10 +15,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let analyzer = common::new_analyzer_from_bytecode(bytecode, LazyWatchdog.in_rc())?;
 
     // Get the final storage layout for the input contract
-    let _layout = analyzer.analyze()?;
+    let layout = analyzer.analyze()?;
 
-    // But really we just ensure that it completes for now, as before it would
-    // always hang
+    // While this contract does make use of storage opcodes (only SLOADs), we
+    // currently saturate our limiters before ever reaching them. More sophisticated
+    // execution strategies will be needed to see them here.
+    //
+    // To that end, the layout we output has no slots.
+    assert!(layout.is_empty());
 
     Ok(())
 }

--- a/tests/cryptoadz_chained_patch.rs
+++ b/tests/cryptoadz_chained_patch.rs
@@ -2,7 +2,7 @@
 //! `CrypToadzChainedPatch` contract`.
 #![cfg(test)]
 
-use storage_layout_analyzer::watchdog::LazyWatchdog;
+use storage_layout_analyzer::{inference::abi::AbiType, watchdog::LazyWatchdog};
 
 mod common;
 
@@ -15,10 +15,13 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let analyzer = common::new_analyzer_from_bytecode(bytecode, LazyWatchdog.in_rc())?;
 
     // Get the final storage layout for the input contract
-    let _layout = analyzer.analyze()?;
+    let layout = analyzer.analyze()?;
 
-    // But really we just ensure that it completes for now, as before it would
-    // always hang
+    // As this contract delegates to another, it only has one storage slot
+    assert_eq!(layout.slot_count(), 1);
+
+    // `address`
+    assert!(layout.has_slot(0, 0, AbiType::Address));
 
     Ok(())
 }

--- a/tests/eip1967_slot.rs
+++ b/tests/eip1967_slot.rs
@@ -4,11 +4,7 @@
 #![cfg(test)]
 
 use ethnum::U256;
-use storage_layout_analyzer::{
-    inference::abi::AbiType,
-    layout::StorageSlot,
-    watchdog::LazyWatchdog,
-};
+use storage_layout_analyzer::{inference::abi::AbiType, watchdog::LazyWatchdog};
 
 mod common;
 
@@ -22,14 +18,14 @@ fn correctly_returns_large_slot() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // Inspect it to check that things are correct
-    assert_eq!(layout.slots().len(), 1);
+    assert_eq!(layout.slot_count(), 1);
 
     // Check that we see a slot at the huge value
-    assert!(layout.slots().contains(&StorageSlot::new(
+    assert!(layout.has_slot(
         U256::from_str_hex("0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc")?,
         0,
         AbiType::Bytes { length: Some(20) }
-    )));
+    ));
 
     Ok(())
 }

--- a/tests/merkle_tree_no_storage_opcodes.rs
+++ b/tests/merkle_tree_no_storage_opcodes.rs
@@ -18,7 +18,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // We should see no slots as this contract never uses storage opcodes.
-    assert!(layout.slots().is_empty());
+    assert!(layout.is_empty());
 
     Ok(())
 }

--- a/tests/mortgage_render.rs
+++ b/tests/mortgage_render.rs
@@ -15,10 +15,10 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let analyzer = common::new_analyzer_from_bytecode(bytecode, LazyWatchdog.in_rc())?;
 
     // Get the final storage layout for the input contract
-    let _layout = analyzer.analyze()?;
+    let layout = analyzer.analyze()?;
 
-    // But really we just ensure that it completes for now, as before it would
-    // always hang
+    // We should have no slots
+    assert!(layout.is_empty());
 
     Ok(())
 }

--- a/tests/packed_encodings.rs
+++ b/tests/packed_encodings.rs
@@ -3,7 +3,7 @@
 //! encodings.
 #![cfg(test)]
 
-use storage_layout_analyzer::{inference::abi::AbiType, layout::StorageSlot};
+use storage_layout_analyzer::inference::abi::AbiType;
 
 mod common;
 
@@ -17,17 +17,13 @@ fn analyses_packed_encodings() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // We should see two 'slots'
-    assert_eq!(layout.slots().len(), 2);
+    assert_eq!(layout.slot_count(), 2);
 
     // Check that we see a slot 0 offset 0 containing bytes8
-    let expected_bytes_8 = AbiType::Bytes { length: Some(8) };
-    let expected_bytes_8_slot = StorageSlot::new(0, 0, expected_bytes_8);
-    assert!(layout.slots().contains(&expected_bytes_8_slot));
+    assert!(layout.has_slot(0, 0, AbiType::Bytes { length: Some(8) }));
 
     // Check that we see a slot 0 offset 64
-    let expected_second_half = AbiType::Bytes { length: Some(16) };
-    let expected_second_half_slot = StorageSlot::new(0, 64, expected_second_half);
-    assert!(layout.slots().contains(&expected_second_half_slot));
+    assert!(layout.has_slot(0, 64, AbiType::Bytes { length: Some(16) }));
 
     // All done
     Ok(())

--- a/tests/sale_clock_auction.rs
+++ b/tests/sale_clock_auction.rs
@@ -4,7 +4,6 @@
 
 use storage_layout_analyzer::{
     inference::abi::{AbiType, StructElement},
-    layout::StorageSlot,
     watchdog::LazyWatchdog,
 };
 
@@ -23,36 +22,24 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
 
     // We should see 8 entries, but we only see 6 due to a lack of discovery of
     // fixed-length arrays, and a missing packed element
-    assert_eq!(layout.slots().len(), 7);
+    assert_eq!(layout.slot_count(), 7);
 
     // `address`, but we infer `number160`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(0, 0, AbiType::Number { size: Some(160) }))
-    );
+    assert!(layout.has_slot(0, 0, AbiType::Number { size: Some(160) }));
 
     // `bool`, packed
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(0, 160, AbiType::Number { size: Some(8) }))
-    );
+    assert!(layout.has_slot(0, 160, AbiType::Number { size: Some(8) }));
 
     // `address`
-    assert!(layout.slots().contains(&StorageSlot::new(1, 0, AbiType::Address)));
+    assert!(layout.has_slot(1, 0, AbiType::Address));
 
     // `uint256` but we infer `numberUnknown`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(2, 0, AbiType::Number { size: None }))
-    );
+    assert!(layout.has_slot(2, 0, AbiType::Number { size: None }));
 
     // `mapping(uint256 => struct(address, uint128, uint128, uint64, uint64)` but we
     // infer `mapping(bytes32 => struct(address, uint128, uint128, conflict,
     // uint65)`
-    assert!(layout.slots().contains(&StorageSlot::new(
+    assert!(layout.has_slot(
         3,
         0,
         AbiType::Mapping {
@@ -67,21 +54,13 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                 ],
             }),
         }
-    )));
+    ));
 
     // `bool` but we infer `number8`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(4, 0, AbiType::Number { size: Some(8) }))
-    );
+    assert!(layout.has_slot(4, 0, AbiType::Number { size: Some(8) }));
 
     // `uint256` but we infer `uintUnknown`
-    assert!(
-        layout
-            .slots()
-            .contains(&StorageSlot::new(5, 0, AbiType::UInt { size: None }))
-    );
+    assert!(layout.has_slot(5, 0, AbiType::UInt { size: None }));
 
     Ok(())
 }

--- a/tests/simple_contract.rs
+++ b/tests/simple_contract.rs
@@ -2,7 +2,7 @@
 //! capabilities on a very simple, hand-constructed, contract.
 #![cfg(test)]
 
-use storage_layout_analyzer::{inference::abi::AbiType, layout::StorageSlot};
+use storage_layout_analyzer::inference::abi::AbiType;
 
 mod common;
 
@@ -16,35 +16,23 @@ fn analyses_simple_contract() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // Inspect it to check that things are correct
-    assert_eq!(layout.slots().len(), 2);
+    assert_eq!(layout.slot_count(), 2);
 
     // Check that we see the `mapping(bytes16 => mapping(bytes16 => bytes32))`
-    let expected_mapping = AbiType::Mapping {
-        key_type:   Box::new(AbiType::Bytes { length: Some(16) }),
-        value_type: Box::new(AbiType::Mapping {
+    assert!(layout.has_slot(
+        0,
+        0,
+        AbiType::Mapping {
             key_type:   Box::new(AbiType::Bytes { length: Some(16) }),
-            value_type: Box::new(AbiType::Bytes { length: Some(32) }),
-        }),
-    };
-    let expected_mapping_slot = StorageSlot::new(0, 0, expected_mapping);
-    assert!(layout.slots().contains(&expected_mapping_slot));
+            value_type: Box::new(AbiType::Mapping {
+                key_type:   Box::new(AbiType::Bytes { length: Some(16) }),
+                value_type: Box::new(AbiType::Bytes { length: Some(32) }),
+            }),
+        }
+    ));
 
-    // Check that we see the `uint64[]`
-    let expected_dyn_array = AbiType::DynArray {
-        // Unfortunately we can't currently work out that it's 64 bit as they use a different
-        // method to scale the values beyond the supported one
-        tp: Box::new(AbiType::UInt { size: None }),
-    };
-    let _expected_array_slot = StorageSlot::new(1, 0, expected_dyn_array);
-
-    // Unfortunately we are currently unable to figure out the `uint64[]`. This is
-    // due to the fact that `solc` uses a packed encoding for such arrays where four
-    // of the integers are packed into a single slot of the dynamic array.
-    //
-    // The analyzer is currently unable to recognise this, as it is part of the
-    // upcoming work
-
-    // assert!(layout.slots().contains(&expected_array_slot));
+    // `uint64[]` but we infer conflict
+    assert!(layout.has_slot(1, 0, AbiType::conflict()));
 
     Ok(())
 }

--- a/tests/uniswap_permit2.rs
+++ b/tests/uniswap_permit2.rs
@@ -4,7 +4,6 @@
 
 use storage_layout_analyzer::{
     inference::abi::{AbiType, StructElement},
-    layout::StorageSlot,
     watchdog::LazyWatchdog,
 };
 
@@ -22,11 +21,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     let layout = analyzer.analyze()?;
 
     // We should see 2 slots
-    assert_eq!(layout.slots().len(), 2);
+    assert_eq!(layout.slot_count(), 2);
 
     // `mapping(address => mapping(uint256 => uint256))` but we infer
     // `mapping(address => mapping(bytes32 => bytesUnknown))`
-    assert!(layout.slots().contains(&StorageSlot::new(
+    assert!(layout.has_slot(
         0,
         0,
         AbiType::Mapping {
@@ -36,12 +35,12 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                 value_type: Box::new(AbiType::Bytes { length: None }),
             }),
         }
-    )));
+    ));
 
     // `mapping(address => mapping(address => mapping(address => struct(uint160,
     // uint48, uint48)))` but we infer `mapping(address => mapping(address =>
     // mapping(address => struct(uint160, uint48, bytes6)))`
-    assert!(layout.slots().contains(&StorageSlot::new(
+    assert!(layout.has_slot(
         1,
         0,
         AbiType::Mapping {
@@ -60,7 +59,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                 }),
             }),
         }
-    )));
+    ));
 
     Ok(())
 }


### PR DESCRIPTION
# Summary

Previously some integration tests were added without accompanying layout assertions due to time constraints and them existing to test other things like termination.

This commit adds the layouts back so that we can increase the coverage of our integration tests.

Closes #63 

# Details

It has highlighted a lack of permissiveness in our `bytes` type inference, filed as #88. 

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
