### PR TITLE
Unify bytes more accurately

### DIFF
--- a/tests/indelible.rs
+++ b/tests/indelible.rs
@@ -32,11 +32,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `uint256` but we infer `numberUnknown`
     assert!(layout.has_slot(1, 0, AbiType::Number { size: None }));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(2, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(2, 0, AbiType::DynBytes));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(3, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(3, 0, AbiType::DynBytes));
 
     // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
     // struct(address, any, number1, number1, any, bytes3))`
@@ -129,7 +129,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     ));
 
     // `mapping(uint256 => mapping(uint256 => struct(string, string)))` but we infer
-    // `mapping(uint256 => mapping(bytes32 => struct(conflict, conflict)))`
+    // `mapping(uint256 => mapping(bytes32 => struct(bytes, bytes)))`
     assert!(layout.has_slot(
         11,
         0,
@@ -139,8 +139,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                 key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
                 value_type: Box::new(AbiType::Struct {
                     elements: vec![
-                        StructElement::new(0, AbiType::conflict()),
-                        StructElement::new(256, AbiType::conflict()),
+                        StructElement::new(0, AbiType::DynBytes),
+                        StructElement::new(256, AbiType::DynBytes),
                     ],
                 }),
             }),
@@ -211,8 +211,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `uint256` but we infer `uintUnknown`
     assert!(layout.has_slot(27, 0, AbiType::UInt { size: None }));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(28, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(28, 0, AbiType::DynBytes));
 
     // `bool` but we infer `packed(number8, bytes31)`
     assert!(layout.has_slot(29, 0, AbiType::Number { size: Some(8) }));
@@ -231,14 +231,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     assert!(layout.has_slot(33, 0, AbiType::Number { size: Some(8) }));
     assert!(layout.has_slot(33, 8, AbiType::Bytes { length: Some(31) }));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(34, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(34, 0, AbiType::DynBytes));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(35, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(35, 0, AbiType::DynBytes));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(36, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(36, 0, AbiType::DynBytes));
 
     // `string` but we infer `packed(number1, uint7)`
     assert!(layout.has_slot(37, 0, AbiType::Number { size: Some(1) }));

--- a/tests/kakigori.rs
+++ b/tests/kakigori.rs
@@ -23,11 +23,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // We should see 17 slots, but we only see 13
     assert_eq!(layout.slot_count(), 13);
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(0, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(0, 0, AbiType::DynBytes));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(1, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(1, 0, AbiType::DynBytes));
 
     // `mapping(uint256 => address)` but we miss it entirely
     assert!(layout.has_no_slot_at(2));

--- a/tests/paw_warz.rs
+++ b/tests/paw_warz.rs
@@ -20,11 +20,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // We should have 10 entries, but we only see 7
     assert_eq!(layout.slot_count(), 7);
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(0, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(0, 0, AbiType::DynBytes));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(1, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(1, 0, AbiType::DynBytes));
 
     // `mapping(uint256 => address)` but we miss it entirely
     assert!(layout.has_no_slot_at(2));
@@ -45,18 +45,18 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `address` but we infer `uintUnknown`
     assert!(layout.has_slot(7, 0, AbiType::UInt { size: None }));
 
-    // `mapping(uint256 => bytes)` but we infer `mapping(bytes32 => conflict)`
+    // `mapping(uint256 => bytes)` but we infer `mapping(bytes32 => bytes)`
     assert!(layout.has_slot(
         8,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
-            value_type: Box::new(AbiType::conflict()),
+            value_type: Box::new(AbiType::DynBytes),
         }
     ));
 
-    // `string` but we infer `conflict`
-    assert!(layout.has_slot(9, 0, AbiType::conflict()));
+    // `string` but we infer `bytes`
+    assert!(layout.has_slot(9, 0, AbiType::DynBytes));
 
     Ok(())
 }

--- a/tests/sale_clock_auction.rs
+++ b/tests/sale_clock_auction.rs
@@ -38,7 +38,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
 
     // `mapping(uint256 => struct(address, uint128, uint128, uint64, uint64)` but we
     // infer `mapping(bytes32 => struct(address, uint128, uint128, conflict,
-    // uint65)`
+    // uint64)`
     assert!(layout.has_slot(
         3,
         0,


### PR DESCRIPTION
# Summary

Previously there were cases that were valid bytes unifications that we would miss due to being too restrictive. We are now far more permissive while still retaining sufficient accuracy to ensure we are not inferring such a type incorrectly.

Closes #88 

# Details

N/A

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
