### PR TITLE
Recognise the proxy slot pattern

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -244,6 +244,7 @@ impl Analyzer<state::VMReady> {
 impl Analyzer<state::ExecutionComplete> {
     /// Takes thew results of execution and uses them to prepare a new inference
     /// engine.
+    #[allow(clippy::missing_panics_doc)] // Explicit closure can never return Err
     #[must_use]
     pub fn prepare_unifier(self) -> Analyzer<state::InferenceReady> {
         unsafe {

--- a/src/constant.rs
+++ b/src/constant.rs
@@ -91,6 +91,9 @@ pub const DEFAULT_CONDITIONAL_JUMP_PER_TARGET_FORK_LIMIT: usize = 50;
 /// culled.
 pub const DEFAULT_VALUE_SIZE_LIMIT: usize = 250;
 
-/// The number of loop iterations the analyzer will wait before polling the
-/// watchdog.
+/// The default number of loop iterations the analyzer will wait before polling
+/// the watchdog.
 pub const DEFAULT_WATCHDOG_POLL_LOOP_ITERATIONS: usize = 100;
+
+/// The value that solidity uses to type tag `string` in ABI encoding.
+pub const SOLIDITY_STRING_POINTER: usize = 0x20;

--- a/src/inference/lift/dynamic_array_access.rs
+++ b/src/inference/lift/dynamic_array_access.rs
@@ -73,8 +73,13 @@ impl Lift for DynamicArrayIndex {
             } else {
                 return None;
             }
-            .clone()
-            .constant_fold();
+            .clone();
+
+            let data = match data.data() {
+                RSVD::Concat { values } if values.len() == 1 => values[0].clone().constant_fold(),
+                RSVD::Concat { .. } => return None,
+                _ => data,
+            };
 
             let access = RSVD::DynamicArrayIndex {
                 slot:  data.transform_data(lift_dyn_array_accesses),

--- a/src/inference/lift/mod.rs
+++ b/src/inference/lift/mod.rs
@@ -7,6 +7,7 @@ pub mod mapping_index;
 pub mod mapping_offset;
 pub mod mul_shifted;
 pub mod packed_encoding;
+pub mod proxy_slots;
 pub mod recognise_hashed_slots;
 pub mod storage_slots;
 pub mod sub_word;
@@ -27,6 +28,7 @@ use crate::{
             mapping_offset::MappingOffset,
             mul_shifted::MulShiftedValue,
             packed_encoding::PackedEncoding,
+            proxy_slots::ProxySlots,
             recognise_hashed_slots::StorageSlotHashes,
             storage_slots::StorageSlots,
             sub_word::SubWordValue,
@@ -130,6 +132,7 @@ impl Default for LiftingPasses {
         Self {
             passes: vec![
                 StorageSlotHashes::new(),
+                ProxySlots::new(),
                 MappingIndex::new(),
                 SubWordValue::new(),
                 MulShiftedValue::new(),

--- a/src/inference/lift/proxy_slots.rs
+++ b/src/inference/lift/proxy_slots.rs
@@ -1,0 +1,654 @@
+//! This module provides a lifting pass that recognises slot indices created
+//! using common patterns for proxy storage in proxy contracts.
+
+use ethnum::U256;
+use itertools::Itertools;
+use sha3::{Digest, Keccak256};
+
+use crate::{
+    constant::SOLIDITY_STRING_POINTER,
+    inference::{lift::Lift, state::InferenceState},
+    vm::value::{known::KnownWord, RuntimeBoxedVal, RSV, RSVD},
+};
+
+/// This pass detects and folds expressions that access slots constructed using
+/// common patterns for proxy contracts.
+///
+/// ```code
+///  s_load(sha3(c), value) where c = constant or concat(...)
+/// s_store(sha3(c), value)
+///
+/// becomes
+///
+///  s_load(slot(s), value) where s is computed
+/// s_store(slot(s), value) where s is computed
+/// ```
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ProxySlots;
+
+impl ProxySlots {
+    /// Constructs a new instance of the proxy slots lifting pass.
+    #[must_use]
+    pub fn new() -> Box<Self> {
+        Box::new(Self)
+    }
+
+    /// Calculates the keccak256 hash of the provided `words` in order, using
+    /// big-endian byte encoding internally to match the EVM.
+    #[allow(clippy::missing_panics_doc)] // Panics are guarded as to never happen
+    #[must_use]
+    pub fn sha3_known_words(words: &[KnownWord]) -> KnownWord {
+        let mut hasher = Keccak256::new();
+
+        for word in words {
+            hasher.update(word.bytes_be());
+        }
+
+        let hash = hasher.finalize().to_vec();
+        let u256 = U256::from_be_bytes(
+            hash.as_slice()
+                .try_into()
+                .expect("The number of bytes in the hash output was not 32"),
+        );
+        KnownWord::from_le(u256)
+    }
+
+    /// Determines if the data in `words` is likely to be a sequence of ascii
+    /// characters.
+    ///
+    /// The string must meet the below likelihood criteria as well as have its
+    /// MSB be non-zero.
+    ///
+    /// # Likelihood
+    ///
+    /// In particular, it collects all bytes in big-endian byte ordering,
+    /// removes any trailing `NUL` bytes, and then checks that all remaining
+    /// bytes fall into the ASCII printable range (`0x1f <= c < 0x7f`).
+    ///
+    /// The chances of _all_ bytes in a byte vector of length `n` being in the
+    /// printable ascii character range is `(95/256) ^ n`, so for reasonable
+    /// length strings we are probabilistically correct.
+    #[must_use]
+    pub fn is_likely_string(words: &[KnownWord]) -> bool {
+        if let Some(first) = words.first() {
+            let msb_non_zero =
+                matches!(first.bytes_be().first(), Some(first_byte) if first_byte != &0);
+            let stripped = Self::strip_trailing_nuls(words);
+            stripped.iter().all(|byte| byte > &0x1f && byte < &0x7f) && msb_non_zero
+        } else {
+            false
+        }
+    }
+
+    /// Asserts that the byte length of the byte string described by `words` is
+    /// `expected_len`.
+    ///
+    /// It does this by dropping any trailing `NUL` bytes in the string and then
+    /// counting the number of bytes.
+    #[must_use]
+    pub fn has_correct_number_of_bytes(words: &[KnownWord], expected_len: KnownWord) -> bool {
+        let stripped = Self::strip_trailing_nuls(words);
+        KnownWord::from(stripped.len()) == expected_len
+    }
+
+    /// Strips any trailing `NUL` bytes in the byte string described by `words`.
+    #[must_use]
+    pub fn strip_trailing_nuls(words: &[KnownWord]) -> Vec<u8> {
+        let all_bytes: Vec<u8> = words.iter().flat_map(KnownWord::bytes_be).collect_vec();
+        let mut no_trailing_nuls = all_bytes
+            .into_iter()
+            .rev()
+            .skip_while(|byte| byte == &0x0)
+            .collect_vec();
+        no_trailing_nuls.reverse();
+
+        no_trailing_nuls
+    }
+}
+
+impl Lift for ProxySlots {
+    fn run(
+        &mut self,
+        value: RuntimeBoxedVal,
+        _state: &InferenceState,
+    ) -> crate::error::unification::Result<RuntimeBoxedVal> {
+        fn unpick_sha3_data(data: &RSVD) -> Option<RSVD> {
+            let RSVD::Sha3 { data } = data else { return None };
+
+            let slot_key = match data.data().clone() {
+                // In this case, we are directly hashing a constant value
+                RSVD::KnownData { value } => {
+                    if ProxySlots::is_likely_string(&[value]) {
+                        ProxySlots::sha3_known_words(&[value])
+                    } else {
+                        return None;
+                    }
+                }
+                RSVD::Concat { values } => {
+                    // First we constant fold all the values to make it more likely we have data to
+                    // work on
+                    let words = values
+                        .iter()
+                        .cloned()
+                        .flat_map(|value| {
+                            let folded = value.constant_fold();
+                            match folded.data() {
+                                RSVD::KnownData { value } => vec![*value],
+                                _ => Vec::new(),
+                            }
+                        })
+                        .collect_vec();
+
+                    // If the vec of words is not the same length as the input values, we don't have
+                    // constants and can't proceed
+                    if words.len() != values.len() {
+                        return None;
+                    }
+
+                    // If we can surmise it to be a non-packed encoding by looking for the string
+                    // pointer in the first index, then we can treat the second index as the length
+                    if words.len() >= 3 && words[0] == KnownWord::from(SOLIDITY_STRING_POINTER) {
+                        let length = words[1];
+                        let string_data = &words[2..];
+
+                        // If the length doesn't match, or it doesn't look like a string, we're
+                        // wrong about the encoding and bail
+                        if !ProxySlots::has_correct_number_of_bytes(string_data, length)
+                            || !ProxySlots::is_likely_string(string_data)
+                        {
+                            return None;
+                        }
+                    } else if !ProxySlots::is_likely_string(words.as_slice()) {
+                        // Even if it does not match an encoding, we expect it to look like a string
+                        return None;
+                    }
+
+                    ProxySlots::sha3_known_words(words.as_slice())
+                }
+                _ => return None,
+            };
+
+            Some(RSVD::new_known(slot_key))
+        }
+
+        fn unpick_proxy_slots(data: &RSVD) -> Option<RSVD> {
+            match data {
+                RSVD::Add { left, right } => {
+                    let (left, right) =
+                        if let Some(new_left_payload) = unpick_sha3_data(left.data()) {
+                            let new_left = RSV::new(
+                                left.instruction_pointer(),
+                                new_left_payload,
+                                left.provenance(),
+                                None,
+                            );
+                            (new_left, right.clone())
+                        } else if let Some(new_right_payload) = unpick_sha3_data(right.data()) {
+                            let new_right = RSV::new(
+                                right.instruction_pointer(),
+                                new_right_payload,
+                                right.provenance(),
+                                None,
+                            );
+                            (left.clone(), new_right)
+                        } else {
+                            return None;
+                        };
+
+                    let add = RSVD::Add { left, right };
+                    let constant_folded = add.constant_fold();
+
+                    if matches!(constant_folded, RSVD::KnownData { .. }) {
+                        Some(constant_folded)
+                    } else {
+                        None
+                    }
+                }
+                _ => unpick_sha3_data(data),
+            }
+        }
+
+        fn recognise_proxy_slots(data: &RSVD) -> Option<RSVD> {
+            match data {
+                RSVD::SLoad { key, value } => Some(RSVD::SLoad {
+                    key:   if let Some(new_key) = unpick_proxy_slots(key.data()) {
+                        RSV::new(key.instruction_pointer(), new_key, key.provenance(), None)
+                    } else {
+                        key.clone().transform_data(recognise_proxy_slots)
+                    },
+                    value: value.clone().transform_data(recognise_proxy_slots),
+                }),
+                RSVD::StorageWrite { key, value } => Some(RSVD::StorageWrite {
+                    key:   if let Some(new_key) = unpick_proxy_slots(key.data()) {
+                        RSV::new(key.instruction_pointer(), new_key, key.provenance(), None)
+                    } else {
+                        key.clone().transform_data(recognise_proxy_slots)
+                    },
+                    value: value.clone().transform_data(recognise_proxy_slots),
+                }),
+                _ => None,
+            }
+        }
+
+        Ok(value.transform_data(recognise_proxy_slots))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ethnum::U256;
+    use itertools::Itertools;
+
+    use crate::{
+        inference::{
+            lift::{proxy_slots::ProxySlots, Lift},
+            state::InferenceState,
+        },
+        vm::value::{known::KnownWord, Provenance, RSV, RSVD},
+    };
+
+    #[test]
+    fn computes_correct_hash_of_words() {
+        // Create the data to be hashed
+        let string_pointer = KnownWord::from(0x20);
+        let string_length = KnownWord::from(0x21);
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        // Check that the result is right
+        let expected_result = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x5a648c35a2f5512218b4683cf10e03f5b7c9dc7346e1bf77d304ae97f60f592b",
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            ProxySlots::sha3_known_words(&[string_pointer, string_length, word_1, word_2]),
+            expected_result
+        );
+        assert_eq!(
+            ProxySlots::sha3_known_words(&[word_1]),
+            ProxySlots::sha3_known_words(&[word_1]),
+        );
+    }
+
+    #[test]
+    fn discovers_likely_uris() {
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        // Check that we get the result correct
+        assert!(ProxySlots::is_likely_string(&[word_1, word_2],));
+    }
+
+    #[test]
+    fn correctly_rejects_non_uri() {
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x1f6f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+
+        // Check that we get the result correct
+        assert!(!ProxySlots::is_likely_string(&[word_1],));
+    }
+
+    #[test]
+    fn correctly_asserts_string_length() {
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        // Check that the result is correct
+        assert!(ProxySlots::has_correct_number_of_bytes(
+            &[word_1, word_2],
+            KnownWord::from(0x21)
+        ));
+    }
+
+    #[test]
+    fn correctly_detects_length_mismatches() {
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7979000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        // Check that the result is correct
+        assert!(!ProxySlots::has_correct_number_of_bytes(
+            &[word_1, word_2],
+            KnownWord::from(0x21)
+        ));
+    }
+
+    #[test]
+    fn correctly_finds_a_direct_constant_slot() -> anyhow::Result<()> {
+        // Create some data to run on
+        let word = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let input_word = RSV::new_known_value(0, word, Provenance::Synthetic, None);
+        let input_value = RSV::new_value(1, Provenance::Synthetic);
+        let input_key = RSV::new_synthetic(2, RSVD::Sha3 { data: input_word });
+        let s_load = RSV::new_synthetic(
+            3,
+            RSVD::SLoad {
+                key:   input_key.clone(),
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Inspect the result
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(value, &input_value);
+
+                match key.data() {
+                    RSVD::KnownData { value } => {
+                        assert_eq!(value, &ProxySlots::sha3_known_words(&[word]));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn correctly_finds_single_word_under_concat() -> anyhow::Result<()> {
+        // Create some data to run on
+        let word = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let input_word = RSV::new_known_value(0, word, Provenance::Synthetic, None);
+        let input_value = RSV::new_value(1, Provenance::Synthetic);
+        let concat = RSV::new_synthetic(
+            2,
+            RSVD::Concat {
+                values: vec![input_word],
+            },
+        );
+        let input_key = RSV::new_synthetic(2, RSVD::Sha3 { data: concat });
+        let s_load = RSV::new_synthetic(
+            3,
+            RSVD::SLoad {
+                key:   input_key.clone(),
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the pass
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Inspect the result
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(value, &input_value);
+
+                match key.data() {
+                    RSVD::KnownData { value } => {
+                        assert_eq!(value, &ProxySlots::sha3_known_words(&[word]));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn correctly_finds_packed_multi_word_under_concat() -> anyhow::Result<()> {
+        // Create the data to test on
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let words = vec![word_1, word_2]
+            .into_iter()
+            .map(|w| RSV::new_known_value(0, w, Provenance::Synthetic, None))
+            .collect_vec();
+        let concat = RSV::new_synthetic(1, RSVD::Concat { values: words });
+        let sha3 = RSV::new_synthetic(2, RSVD::Sha3 { data: concat });
+        let input_value = RSV::new_value(3, Provenance::Synthetic);
+        let s_load = RSV::new_synthetic(
+            4,
+            RSVD::SLoad {
+                key:   sha3,
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the lifting
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Check that the result is sane
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(value, &input_value);
+
+                match key.data() {
+                    RSVD::KnownData { value } => {
+                        assert_eq!(value, &ProxySlots::sha3_known_words(&[word_1, word_2]));
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn ignores_common_mapping_patterns() -> anyhow::Result<()> {
+        // Create the data to test on
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex("0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50")
+                .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000007380000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let words = vec![word_1, word_2]
+            .into_iter()
+            .map(|w| RSV::new_known_value(0, w, Provenance::Synthetic, None))
+            .collect_vec();
+        let concat = RSV::new_synthetic(1, RSVD::Concat { values: words });
+        let sha3 = RSV::new_synthetic(2, RSVD::Sha3 { data: concat });
+        let input_value = RSV::new_value(3, Provenance::Synthetic);
+        let s_load = RSV::new_synthetic(
+            4,
+            RSVD::SLoad {
+                key:   sha3.clone(),
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the lifting
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Check that the result is sane
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(key, &sha3);
+                assert_eq!(value, &input_value);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn correctly_finds_abi_encoded_with_length() -> anyhow::Result<()> {
+        // Create the data to test on
+        let string_pointer = KnownWord::from(0x20);
+        let string_length = KnownWord::from(0x21);
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let words = vec![string_pointer, string_length, word_1, word_2]
+            .into_iter()
+            .map(|w| RSV::new_known_value(0, w, Provenance::Synthetic, None))
+            .collect_vec();
+        let concat = RSV::new_synthetic(1, RSVD::Concat { values: words });
+        let sha3 = RSV::new_synthetic(2, RSVD::Sha3 { data: concat });
+        let input_value = RSV::new_value(3, Provenance::Synthetic);
+        let s_load = RSV::new_synthetic(
+            4,
+            RSVD::SLoad {
+                key:   sha3,
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the lifting
+        let expected_result = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x5a648c35a2f5512218b4683cf10e03f5b7c9dc7346e1bf77d304ae97f60f592b",
+            )
+            .unwrap(),
+        );
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Check that the result is sane
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(value, &input_value);
+
+                match key.data() {
+                    RSVD::KnownData { value } => {
+                        assert_eq!(value, &expected_result);
+                    }
+                    _ => panic!("Incorrect payload"),
+                }
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn errors_if_abi_encoded_string_has_wrong_length() -> anyhow::Result<()> {
+        // Create the data to test on
+        let string_pointer = KnownWord::from(0x20);
+        let string_length = KnownWord::from(0x22);
+        let word_1 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f78",
+            )
+            .unwrap(),
+        );
+        let word_2 = KnownWord::from_le(
+            U256::from_str_hex(
+                "0x7900000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let words = vec![string_pointer, string_length, word_1, word_2]
+            .into_iter()
+            .map(|w| RSV::new_known_value(0, w, Provenance::Synthetic, None))
+            .collect_vec();
+        let concat = RSV::new_synthetic(1, RSVD::Concat { values: words });
+        let sha3 = RSV::new_synthetic(2, RSVD::Sha3 { data: concat });
+        let input_value = RSV::new_value(3, Provenance::Synthetic);
+        let s_load = RSV::new_synthetic(
+            4,
+            RSVD::SLoad {
+                key:   sha3.clone(),
+                value: input_value.clone(),
+            },
+        );
+
+        // Run the lifting
+        let state = InferenceState::empty();
+        let result = ProxySlots.run(s_load, &state)?;
+
+        // Check that the result is sane
+        match result.data() {
+            RSVD::SLoad { key, value } => {
+                assert_eq!(key, &sha3);
+                assert_eq!(value, &input_value);
+            }
+            _ => panic!("Incorrect payload"),
+        }
+
+        Ok(())
+    }
+}

--- a/src/inference/lift/recognise_hashed_slots.rs
+++ b/src/inference/lift/recognise_hashed_slots.rs
@@ -43,6 +43,7 @@ impl StorageSlotHashes {
 
     /// Generates the slot hashes for the first `count` slots, assuming
     /// big-endian (network) byte ordering.
+    #[allow(clippy::missing_panics_doc)] // Panics are guarded and should never happen
     #[must_use]
     pub fn make_hashes(count: usize) -> BiMap<U256, usize> {
         let mut data = BiMap::new();
@@ -110,7 +111,7 @@ mod test {
     #[allow(clippy::needless_range_loop)] // Clearer way to write it for the test
     fn computes_first_five_hashes_correctly() {
         // A vec of expected hashes
-        let hashes = vec![
+        let hashes = [
             "290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563",
             "b10e2d527612073b26eecdfd717e6a320cf44b4afac2b0732d9fcbe2b7fa0cf6",
             "405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ace",

--- a/src/inference/state.rs
+++ b/src/inference/state.rs
@@ -468,6 +468,7 @@ impl InferenceState {
     ///
     /// If any one `value` has no associated variable, it is registered in the
     /// state.
+    #[allow(clippy::missing_panics_doc)] // Panics are guarded
     pub fn infer_for_many<const N: usize>(
         &mut self,
         values: [&TCBoxedVal; N],

--- a/src/inference/unification/mod.rs
+++ b/src/inference/unification/mod.rs
@@ -37,6 +37,7 @@ pub type UnificationForest = DisjointSet<TypeVariable, InferenceSet>;
 /// # Errors
 ///
 /// Returns [`Err`] if unification is halted by the watchdog.
+#[allow(clippy::missing_panics_doc)] // Panics are all guarded
 pub fn unify(state: &mut InferenceState, watchdog: &DynWatchdog) -> Result<()> {
     // First we have to create our forest.
     let mut forest = UnificationForest::new();
@@ -889,7 +890,7 @@ mod test {
 
             match result.unwrap() {
                 TE::DynamicArray { element } => {
-                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                    assert!([elem_1_tv, elem_2_tv].contains(&element));
                 }
                 _ => panic!("Bad payload in result"),
             }
@@ -931,7 +932,7 @@ mod test {
 
             match result.unwrap() {
                 TE::DynamicArray { element } => {
-                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                    assert!([elem_1_tv, elem_2_tv].contains(&element));
                 }
                 _ => panic!("Bad payload in result"),
             }
@@ -984,7 +985,7 @@ mod test {
             // Check the result is right
             match result.unwrap() {
                 TE::FixedArray { element, length } if length == input_len => {
-                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                    assert!([elem_1_tv, elem_2_tv].contains(&element));
                 }
                 _ => panic!("Bad payload in result"),
             }
@@ -1033,7 +1034,7 @@ mod test {
             // Check the result is right
             match result.unwrap() {
                 TE::FixedArray { element, length } if length == input_len => {
-                    assert!(vec![elem_1_tv, elem_2_tv].contains(&element));
+                    assert!([elem_1_tv, elem_2_tv].contains(&element));
                 }
                 _ => panic!("Bad payload in result"),
             }
@@ -1125,8 +1126,8 @@ mod test {
         let result = util::get_inference(mapping_tv, state.result());
         match result.unwrap() {
             TE::Mapping { key, value } => {
-                assert!(vec![key_1_tv, key_2_tv].contains(&key));
-                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+                assert!([key_1_tv, key_2_tv].contains(&key));
+                assert!([value_1_tv, value_2_tv].contains(&value));
             }
             _ => panic!("Invalid payload"),
         }
@@ -1173,8 +1174,8 @@ mod test {
         let result = util::get_inference(mapping_tv, state.result());
         match result.unwrap() {
             TE::Mapping { key, value } => {
-                assert!(vec![key_1_tv, key_2_tv].contains(&key));
-                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+                assert!([key_1_tv, key_2_tv].contains(&key));
+                assert!([value_1_tv, value_2_tv].contains(&value));
             }
             _ => panic!("Invalid payload"),
         }
@@ -1224,8 +1225,8 @@ mod test {
         let result = util::get_inference(mapping_tv, state.result());
         match result.unwrap() {
             TE::Mapping { key, value } => {
-                assert!(vec![key_1_tv, key_2_tv].contains(&key));
-                assert!(vec![value_1_tv, value_2_tv].contains(&value));
+                assert!([key_1_tv, key_2_tv].contains(&key));
+                assert!([value_1_tv, value_2_tv].contains(&value));
             }
             _ => panic!("Invalid payload"),
         }

--- a/src/opcode/memory.rs
+++ b/src/opcode/memory.rs
@@ -1220,6 +1220,7 @@ impl PushN {
 
     /// Gets the bytes that are pushed as a known word.
     #[must_use]
+    #[allow(clippy::missing_panics_doc)] // Unwrapped array has known size
     pub fn bytes_as_word(&self) -> KnownWord {
         // Get the bytes we have and extend them out to be long enough
         let mut bytes = self.bytes.clone();

--- a/src/vm/data.rs
+++ b/src/vm/data.rs
@@ -142,6 +142,7 @@ pub struct JumpTargets {
 
 impl JumpTargets {
     /// Creates a new tracker for jump targets.
+    #[allow(clippy::missing_panics_doc)] // Instructions len has already been checked
     #[must_use]
     pub fn new(instructions: ExecutionThread, maximum_forks_per_jump_target: usize) -> Self {
         let instructions_len = instructions.len();

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -139,6 +139,7 @@ impl VM {
     ///
     /// Note that if this errors, it will still be possible to collect any
     /// stored state information for as far as execution proceeded.
+    #[allow(clippy::missing_panics_doc)] // All panics are guarded by conditions
     pub fn execute(&mut self) -> std::result::Result<(), Errors> {
         let poll_interval = self.watchdog.poll_every();
         let mut counter = 0;
@@ -214,6 +215,7 @@ impl VM {
     ///
     /// If the virtual machine cannot be advanced, or if advancing would result
     /// in the virtual machine pointing to an invalid instruction.
+    #[allow(clippy::missing_panics_doc)] // All panics are guarded by impossible conditions
     pub fn advance(&mut self) -> Result<()> {
         if self.thread_queue.is_empty() {
             return Err(Error::InvalidStep.locate(self.instructions_len()));

--- a/src/vm/state/memory.rs
+++ b/src/vm/state/memory.rs
@@ -191,6 +191,7 @@ impl Memory {
     /// size if so, and [`None`] otherwise.
     #[must_use]
     fn decompose_size(size: &RuntimeBoxedVal) -> Option<usize> {
+        let size = size.clone().constant_fold();
         match size.data() {
             RSVD::KnownData { value } => Some(value.into()),
             _ => None,

--- a/src/vm/state/storage.rs
+++ b/src/vm/state/storage.rs
@@ -68,6 +68,7 @@ impl Storage {
     ///
     /// This is a best-effort analysis as we cannot guarantee knowing if there
     /// have been overwrites between adjacent slots.
+    #[allow(clippy::missing_panics_doc)] // Panics are guarded
     #[must_use]
     pub fn load(&mut self, key: &RuntimeBoxedVal) -> RuntimeBoxedVal {
         // First we need to work out which of the maps to read from.
@@ -143,7 +144,7 @@ impl Storage {
         let mut known_keys: Vec<&RuntimeBoxedVal> = self.known_slots.keys().collect();
         let symbolic_keys: Vec<&RuntimeBoxedVal> = self.symbolic_slots.keys().collect();
 
-        known_keys.extend(symbolic_keys.into_iter());
+        known_keys.extend(symbolic_keys);
 
         known_keys
     }

--- a/src/vm/value/known.rs
+++ b/src/vm/value/known.rs
@@ -159,6 +159,18 @@ impl KnownWord {
         bits
     }
 
+    /// Gets the bytes of this word in little endian ordering.
+    #[must_use]
+    pub fn bytes_le(&self) -> [u8; mem::size_of::<Self>()] {
+        self.value.to_le_bytes()
+    }
+
+    /// Gets the bytes of this word in big endian ordering.
+    #[must_use]
+    pub fn bytes_be(&self) -> [u8; mem::size_of::<Self>()] {
+        self.value.to_be_bytes()
+    }
+
     /// Performs signed division of two known words.
     #[must_use]
     pub fn signed_div(self, rhs: Self) -> Self {

--- a/src/vm/value/mod.rs
+++ b/src/vm/value/mod.rs
@@ -1243,10 +1243,6 @@ where
                         _ => SVD::RightShift { shift, value },
                     })
                 }
-                SVD::Concat { values } if values.len() == 1 => values
-                    .first()
-                    .cloned()
-                    .map(|v| v.transform_data(constant_folder).data),
                 _ => None,
             }
         }

--- a/tests/balancers_vault.rs
+++ b/tests/balancers_vault.rs
@@ -190,8 +190,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     ));
 
     // `mapping(bytes32 => struct)` but we infer `mapping(struct(bytes10, uint16,
-    // bytes20) => struct(number160, number160, mapping(bytes32 => struct(uint112,
-    // uint112, number112, number112))))`
+    // bytes20) => struct(number160, number160, mapping(any => struct(uint112,
+    // number112, number112, number112))))`
     assert!(layout.has_slot(
         9,
         0,
@@ -210,11 +210,11 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
                     StructElement::new(
                         512,
                         AbiType::Mapping {
-                            key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
+                            key_type:   Box::new(AbiType::Any),
                             value_type: Box::new(AbiType::Struct {
                                 elements: vec![
                                     StructElement::new(0, AbiType::UInt { size: Some(112) }),
-                                    StructElement::new(112, AbiType::UInt { size: Some(112) }),
+                                    StructElement::new(112, AbiType::Number { size: Some(112) }),
                                     StructElement::new(256, AbiType::Number { size: Some(112) }),
                                     StructElement::new(368, AbiType::Number { size: Some(112) }),
                                 ],

--- a/tests/cryptoadz_custom_image_37b.rs
+++ b/tests/cryptoadz_custom_image_37b.rs
@@ -25,7 +25,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         0,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::Bytes { length: None }),
+            key_type:   Box::new(AbiType::Bytes { length: Some(1) }),
             value_type: Box::new(AbiType::Number { size: Some(16) }),
         }
     ));

--- a/tests/house.rs
+++ b/tests/house.rs
@@ -26,8 +26,8 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `address` but we infer `number160`
     assert!(layout.has_slot(0, 0, AbiType::Number { size: Some(160) }));
 
-    // `uint256`
-    assert!(layout.has_slot(1, 0, AbiType::UInt { size: Some(256) }));
+    // `uint256` but we infer `number256`
+    assert!(layout.has_slot(1, 0, AbiType::Number { size: Some(256) }));
 
     // `address`
     assert!(layout.has_slot(2, 0, AbiType::Address));
@@ -63,16 +63,16 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `string` but we infer `bytes`
     assert!(layout.has_slot(12, 0, AbiType::DynBytes));
 
-    // `mapping(uint256 => struct)` but we infer `mapping(uint256 => struct)` but
+    // `mapping(uint256 => struct)` but we infer `mapping(number256 => struct)` but
     // the struct is not quite the same
     assert!(layout.has_slot(
         13,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
-                    StructElement::new(0, AbiType::UInt { size: Some(256) }),
+                    StructElement::new(0, AbiType::Number { size: Some(256) }),
                     StructElement::new(256, AbiType::Address),
                     StructElement::new(416, AbiType::Number { size: Some(8) }),
                     StructElement::new(512, AbiType::Bytes { length: Some(32) }),
@@ -101,45 +101,45 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `uint256` but we infer `numberUnknown`
     assert!(layout.has_slot(15, 0, AbiType::Number { size: None }));
 
-    // `mapping(uint256 => uint256)`
+    // `mapping(uint256 => uint256)` but we infer `mapping(number256 => uint256)`
     assert!(layout.has_slot(
         16,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: Some(256) }),
         }
     ));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
     // numberUnknown)`
     assert!(layout.has_slot(
         17,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::Number { size: None }),
         }
     ));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
     // uintUnknown)`
     assert!(layout.has_slot(
         18,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     ));
 
     // `mapping(uint256 => mapping(uint256 => uint256))` but we infer
-    // `mapping(uint256 => mapping(bytes32 => uint256))`
+    // `mapping(number256 => mapping(bytes32 => uint256))`
     assert!(layout.has_slot(
         19,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::Mapping {
                 key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
@@ -147,42 +147,43 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(address => mapping(uint256 => uint256))`
+    // `mapping(address => mapping(uint256 => uint256))` but we infer
+    // `mapping(address => mapping(number256 => uint256))`
     assert!(layout.has_slot(
         20,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
             }),
         }
     ));
 
     // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(uint256 => uintUnknown))`
+    // `mapping(address => mapping(number256 => uintUnknown))`
     assert!(layout.has_slot(
         21,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: None }),
             }),
         }
     ));
 
     // `mapping(address => mapping(uint256 => mapping(uint256 => uint256)))` but we
-    // infer `mapping(address => mapping(uint256 => mapping(bytes32 => uint256))`
+    // infer `mapping(address => mapping(number256 => mapping(bytes32 => uint256))`
     assert!(layout.has_slot(
         22,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::Mapping {
                     key_type:   Box::new(AbiType::Bytes { length: Some(32) }),
                     value_type: Box::new(AbiType::UInt { size: Some(256) }),
@@ -191,28 +192,29 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(address => mapping(uint256 => uint256))`
+    // `mapping(address => mapping(uint256 => uint256))` but we infer
+    // `mapping(address => mapping(number256 => uint256))`
     assert!(layout.has_slot(
         23,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::UInt { size: Some(256) }),
             }),
         }
     ));
 
     // `mapping(address => mapping(uint256 => uint256))` but we infer
-    // `mapping(address => mapping(uint256 => struct))`
+    // `mapping(address => mapping(number256 => struct(number8, bytes31)))`
     assert!(layout.has_slot(
         24,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::Struct {
                     elements: vec![
                         StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -224,14 +226,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     ));
 
     // `mapping(address => mapping(uint256 => bool))` but we infer
-    // `mapping(address => mapping(uint256 => struct(number8, bytes31)))`
+    // `mapping(address => mapping(number256 => struct(number8, bytes31)))`
     assert!(layout.has_slot(
         25,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Address),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+                key_type:   Box::new(AbiType::Number { size: Some(256) }),
                 value_type: Box::new(AbiType::Struct {
                     elements: vec![
                         StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -273,13 +275,13 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(address => uint256)` but we infer `mapping(bytes20 => any)`
+    // `mapping(address => uint256)` but we infer `mapping(bytes20 => numberNone)`
     assert!(layout.has_slot(
         29,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Bytes { length: Some(20) }),
-            value_type: Box::new(AbiType::Any),
+            value_type: Box::new(AbiType::Number { size: None }),
         }
     ));
 
@@ -292,12 +294,13 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(uint256 => bool)` but we infer `mapping(uint256 => struct)`
+    // `mapping(uint256 => bool)` but we infer `mapping(number256 => struct(number8,
+    // bytes31))`
     assert!(layout.has_slot(
         31,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
                     StructElement::new(0, AbiType::Number { size: Some(8) }),
@@ -307,24 +310,24 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
     // uintUnknown)`
     assert!(layout.has_slot(
         32,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     ));
 
-    // `mapping(uint256 => uint256)` but we infer `mapping(uint256 =>
+    // `mapping(uint256 => uint256)` but we infer `mapping(number256 =>
     // uintUnknown)`
     assert!(layout.has_slot(
         33,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(256) }),
+            key_type:   Box::new(AbiType::Number { size: Some(256) }),
             value_type: Box::new(AbiType::UInt { size: None }),
         }
     ));

--- a/tests/indelible.rs
+++ b/tests/indelible.rs
@@ -164,7 +164,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     ));
 
     // `mapping(uint256 => mapping(uint256 => uint256[]))` but we infer
-    // `mapping(number256 => mapping(uint256 => uintUnknown[]))`
+    // `mapping(number256 => mapping(uint256 => uint256[]))`
     assert!(layout.has_slot(
         13,
         0,
@@ -173,7 +173,7 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
             value_type: Box::new(AbiType::Mapping {
                 key_type:   Box::new(AbiType::UInt { size: Some(256) }),
                 value_type: Box::new(AbiType::DynArray {
-                    tp: Box::new(AbiType::UInt { size: None }),
+                    tp: Box::new(AbiType::UInt { size: Some(256) }),
                 }),
             }),
         }

--- a/tests/proxy_slot_pattern_slot.rs
+++ b/tests/proxy_slot_pattern_slot.rs
@@ -1,0 +1,62 @@
+//! This module tests the library's analysis capabilities on the local following
+//! reproduction contract.
+//!
+//! ```text
+//! contract ProxyStorage {
+//!     bytes32 private constant _SLOT_PROXY_STORAGE = keccak256(abi.encode("io.synthetix.core-contracts.Proxy"));
+//!
+//!     struct ProxyStore {
+//!         address implementation;
+//!     }
+//!
+//!     function _proxyStore() internal pure returns (ProxyStore storage store) {
+//!         bytes32 s = _SLOT_PROXY_STORAGE;
+//!         assembly {
+//!             store.slot := s
+//!         }
+//!     }
+//! }
+//!
+//! contract UUPSProxyWithOwner is ProxyStorage {
+//!     function _forward() public {
+//!         address implementation = _getImplementation();
+//!     }
+//!
+//!     function _getImplementation() internal view virtual returns (address) {
+//!         return _proxyStore().implementation;
+//!     }
+//! }
+//! ```
+//!
+//! This contract exposes a proxy slot at a high hashed address, and we want to
+//! be able to discover this slot even in the absence of constant-folded slot
+//! keys.
+#![cfg(test)]
+
+use ethnum::U256;
+use storage_layout_analyzer::{inference::abi::AbiType, watchdog::LazyWatchdog};
+
+mod common;
+
+/// Tests the analyser on the bytecode of the above contract.
+#[test]
+fn correctly_generates_a_layout() -> anyhow::Result<()> {
+    // Create the analyzer
+    let bytecode = "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063a168a4cb14610030575b600080fd5b61003861003a565b005b6000610044610049565b905050565b600061005361007c565b60000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16905090565b60008060405160200161008e90610130565b6040516020818303038152906040528051906020012090508091505090565b600082825260208201905092915050565b7f696f2e73796e7468657469782e636f72652d636f6e7472616374732e50726f7860008201527f7900000000000000000000000000000000000000000000000000000000000000602082015250565b600061011a6021836100ad565b9150610125826100be565b604082019050919050565b600060208201905081810360008301526101498161010d565b905091905056fea264697066735822122098cb622ce5bec4bbbb0da40f9fd3727a2edb1a72e38d1fbe5c6396566e6d6cbb64736f6c63430008110033";
+    let analyzer = common::new_analyzer_from_bytecode(bytecode, LazyWatchdog.in_rc())?;
+
+    // Get the final storage layout for the input contract
+    let layout = analyzer.analyze()?;
+
+    // We should see no slots as this contract never uses storage opcodes.
+    assert_eq!(layout.slot_count(), 1);
+
+    // `address`, but we infer `uintUnknown` due to lack of information
+    assert!(layout.has_slot(
+        U256::from_str_hex("0x5a648c35a2f5512218b4683cf10e03f5b7c9dc7346e1bf77d304ae97f60f592b")?,
+        0,
+        AbiType::UInt { size: None }
+    ));
+
+    Ok(())
+}

--- a/tests/shardwallet.rs
+++ b/tests/shardwallet.rs
@@ -29,12 +29,12 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     // `string` but we never see it
     assert!(layout.has_no_slot_at(1));
 
-    // `mapping(uint256 => address)` but we infer `mapping(uint64 => address)`
+    // `mapping(uint256 => address)` but we infer `mapping(infiniteType => address)`
     assert!(layout.has_slot(
         2,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(64) }),
+            key_type:   Box::new(AbiType::InfiniteType),
             value_type: Box::new(AbiType::Address),
         }
     ));
@@ -49,13 +49,13 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
         }
     ));
 
-    // `mapping(uint256 => address)` but we infer `mapping(uint64 => struct(bytes20,
-    // bytes12)`
+    // `mapping(uint256 => address)` but we infer `mapping(infiniteType =>
+    // struct(bytes20, bytes12)`
     assert!(layout.has_slot(
         4,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(64) }),
+            key_type:   Box::new(AbiType::InfiniteType),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
                     StructElement::new(0, AbiType::Bytes { length: Some(20) }),
@@ -90,17 +90,18 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     assert!(layout.has_slot(6, 224, AbiType::Any));
 
     // `mapping(uint64 => struct(uint24, uint64, uint64))` but we infer
-    // `mapping(uint64 => struct(bytes3, infiniteType, uint64))`
+    // `mapping(infiniteType => struct(number24, infiniteType, uint64, any))`
     assert!(layout.has_slot(
         7,
         0,
         AbiType::Mapping {
-            key_type:   Box::new(AbiType::UInt { size: Some(64) }),
+            key_type:   Box::new(AbiType::InfiniteType),
             value_type: Box::new(AbiType::Struct {
                 elements: vec![
-                    StructElement::new(0, AbiType::Bytes { length: Some(3) }),
+                    StructElement::new(0, AbiType::Number { size: Some(24) }),
                     StructElement::new(24, AbiType::InfiniteType),
-                    StructElement::new(88, AbiType::UInt { size: Some(64) })
+                    StructElement::new(88, AbiType::UInt { size: Some(64) }),
+                    StructElement::new(152, AbiType::Any),
                 ],
             }),
         }
@@ -120,14 +121,14 @@ fn correctly_generates_a_layout() -> anyhow::Result<()> {
     ));
 
     // `mapping(address => mapping(uint64 => uint256))` but we infer
-    // `mapping(bytes20 => mapping(uint64 => uintUnknown))`
+    // `mapping(bytes20 => mapping(infiniteType => uintUnknown))`
     assert!(layout.has_slot(
         9,
         0,
         AbiType::Mapping {
             key_type:   Box::new(AbiType::Bytes { length: Some(20) }),
             value_type: Box::new(AbiType::Mapping {
-                key_type:   Box::new(AbiType::UInt { size: Some(64) }),
+                key_type:   Box::new(AbiType::InfiniteType),
                 value_type: Box::new(AbiType::UInt { size: None }),
             }),
         }


### PR DESCRIPTION
# Summary

This commit implements a feature for the analyzer to recognise the commonly used proxy-slot pattern. It does this by a limited form of constant folding for values that are likely to be hashes of encoded strings.

This commit also improves the analyzer by causing it to constant fold lengths in memory reads, thereby giving itself more accurate information about the values actually being passed around in the program.

Closes #91
Closes #93 

# Details

The usual, please!

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
