### PR TITLE
Fix watchdog polling counter in unification

### DIFF
--- a/src/inference/unification/mod.rs
+++ b/src/inference/unification/mod.rs
@@ -109,7 +109,7 @@ pub fn unify(state: &mut InferenceState, watchdog: &DynWatchdog) -> Result<()> {
             forest.set_data(&ty_var, InferenceSet::from([current]));
 
             // Bump our polling counter
-            counter += 0;
+            counter += 1;
         }
 
         // When we get to the end of that loop, we need to insert the new type variables


### PR DESCRIPTION
# Summary

Fixing the polling counter as it was never incremented.

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.
