### PR TITLE
Allow external construction of the storage slot hashes

### DIFF
--- a/src/inference/lift/mod.rs
+++ b/src/inference/lift/mod.rs
@@ -68,8 +68,10 @@ pub struct LiftingPasses {
 impl LiftingPasses {
     /// Creates a new instance of the lifting pass with the provided `passes`
     #[must_use]
-    pub fn new(passes: Vec<Box<dyn Lift>>) -> Self {
-        Self { passes }
+    pub fn new(passes: impl Into<Vec<Box<dyn Lift>>>) -> Self {
+        Self {
+            passes: passes.into(),
+        }
     }
 
     /// Adds the `pass` to the end of the pass ordering.


### PR DESCRIPTION
# Summary

Adds support for external construction of the storage slot hashes

# Details 
- Adds a new method to `StorageSlotHashes` so it can be constructed with a predefined BitMap of the hashes. 
- Adds a new method to `LiftingPasses` so it can be constructed with a vector of passes 

# Checklist

- [x] Code is formatted by Rustfmt.
- [x] Documentation has been updated if necessary.

Fixes #97 